### PR TITLE
configure maven-javadoc-plugin with additionalOptions -Xdoclint:none …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,7 @@
             </goals>
             <configuration>
               <source>8</source>
+              <additionalOptions>-Xdoclint:none</additionalOptions>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
             </goals>
             <configuration>
               <source>8</source>
-              <additionalOptions>-Xdoclint:none</additionalOptions>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
…to ignore javadoc errors