### PR TITLE
add hash code override methods where equals method is overwritten

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,12 @@
       <version>2.1.0</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <version>3.16.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <directory>${project.basedir}/target</directory>

--- a/src/main/java/com/teragrep/pth_06/config/ConditionConfig.java
+++ b/src/main/java/com/teragrep/pth_06/config/ConditionConfig.java
@@ -116,8 +116,7 @@ public final class ConditionConfig {
             return false;
         final ConditionConfig cast = (ConditionConfig) object;
         return bloomEnabled == cast.bloomEnabled && streamQuery == cast.streamQuery
-                && withoutFilters == cast.withoutFilters && ctx == cast.ctx
-                && bloomTermId == cast.bloomTermId();
+                && withoutFilters == cast.withoutFilters && ctx == cast.ctx && bloomTermId == cast.bloomTermId;
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/config/ConditionConfig.java
+++ b/src/main/java/com/teragrep/pth_06/config/ConditionConfig.java
@@ -116,7 +116,8 @@ public final class ConditionConfig {
             return false;
         final ConditionConfig cast = (ConditionConfig) object;
         return this.bloomEnabled == cast.bloomEnabled && this.streamQuery == cast.streamQuery
-                && this.withoutFilters == cast.withoutFilters && this.ctx == cast.ctx && this.bloomTermId == cast.bloomTermId();
+                && this.withoutFilters == cast.withoutFilters && this.ctx == cast.ctx
+                && this.bloomTermId == cast.bloomTermId();
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/config/ConditionConfig.java
+++ b/src/main/java/com/teragrep/pth_06/config/ConditionConfig.java
@@ -115,9 +115,9 @@ public final class ConditionConfig {
         if (object == null || object.getClass() != this.getClass())
             return false;
         final ConditionConfig cast = (ConditionConfig) object;
-        return this.bloomEnabled == cast.bloomEnabled && this.streamQuery == cast.streamQuery
-                && this.withoutFilters == cast.withoutFilters && this.ctx == cast.ctx
-                && this.bloomTermId == cast.bloomTermId();
+        return bloomEnabled == cast.bloomEnabled && streamQuery == cast.streamQuery
+                && withoutFilters == cast.withoutFilters && ctx == cast.ctx
+                && bloomTermId == cast.bloomTermId();
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/config/ConditionConfig.java
+++ b/src/main/java/com/teragrep/pth_06/config/ConditionConfig.java
@@ -47,6 +47,8 @@ package com.teragrep.pth_06.config;
 
 import org.jooq.DSLContext;
 
+import java.util.Objects;
+
 public final class ConditionConfig {
 
     private final DSLContext ctx;
@@ -105,16 +107,20 @@ public final class ConditionConfig {
         return streamQuery;
     }
 
+    //* DSLContext must be same instance to be equal */
     @Override
     public boolean equals(Object object) {
         if (this == object)
             return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
+        if (object == null || object.getClass() != this.getClass())
             return false;
         final ConditionConfig cast = (ConditionConfig) object;
         return this.bloomEnabled == cast.bloomEnabled && this.streamQuery == cast.streamQuery
-                && this.withoutFilters == cast.withoutFilters && this.ctx == cast.ctx;
+                && this.withoutFilters == cast.withoutFilters && this.ctx == cast.ctx && this.bloomTermId == cast.bloomTermId();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ctx, streamQuery, bloomEnabled, withoutFilters, bloomTermId);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/CategoryTableImpl.java
+++ b/src/main/java/com/teragrep/pth_06/planner/CategoryTableImpl.java
@@ -169,13 +169,11 @@ public final class CategoryTableImpl implements CategoryTable {
     public boolean equals(final Object object) {
         if (this == object)
             return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
+        if (object == null || object.getClass() != this.getClass())
             return false;
         final CategoryTableImpl cast = (CategoryTableImpl) object;
-        return this.originTable.equals(cast.originTable) && this.ctx == cast.ctx && // equal only if same instance of DSLContext
-                this.bloomTermId == cast.bloomTermId && this.tableFilters.equals(cast.tableFilters);
+        return originTable.equals(cast.originTable) && ctx == cast.ctx && // equal only if same instance of DSLContext
+                bloomTermId == cast.bloomTermId && tableFilters.equals(cast.tableFilters) && tableCondition.equals(cast.tableCondition);
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/CategoryTableImpl.java
+++ b/src/main/java/com/teragrep/pth_06/planner/CategoryTableImpl.java
@@ -173,7 +173,8 @@ public final class CategoryTableImpl implements CategoryTable {
             return false;
         final CategoryTableImpl cast = (CategoryTableImpl) object;
         return originTable.equals(cast.originTable) && ctx == cast.ctx && // equal only if same instance of DSLContext
-                bloomTermId == cast.bloomTermId && tableFilters.equals(cast.tableFilters) && tableCondition.equals(cast.tableCondition);
+                bloomTermId == cast.bloomTermId && tableFilters.equals(cast.tableFilters)
+                && tableCondition.equals(cast.tableCondition);
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/CategoryTableImpl.java
+++ b/src/main/java/com/teragrep/pth_06/planner/CategoryTableImpl.java
@@ -53,6 +53,8 @@ import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 import static org.jooq.impl.SQLDataType.BIGINTUNSIGNED;
 
 /**
@@ -174,5 +176,10 @@ public final class CategoryTableImpl implements CategoryTable {
         final CategoryTableImpl cast = (CategoryTableImpl) object;
         return this.originTable.equals(cast.originTable) && this.ctx == cast.ctx && // equal only if same instance of DSLContext
                 this.bloomTermId == cast.bloomTermId && this.tableFilters.equals(cast.tableFilters);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ctx, originTable, bloomTermId, tableCondition, tableFilters);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/PatternMatchTables.java
+++ b/src/main/java/com/teragrep/pth_06/planner/PatternMatchTables.java
@@ -112,12 +112,10 @@ public final class PatternMatchTables {
     public boolean equals(final Object object) {
         if (this == object)
             return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
+        if (object == null || object.getClass() != this.getClass())
             return false;
         final PatternMatchTables cast = (PatternMatchTables) object;
-        return this.patternMatchCondition.equals(cast.patternMatchCondition) && this.ctx == cast.ctx; // only same instance of DSLContext is equal
+        return patternMatchCondition.equals(cast.patternMatchCondition) && ctx == cast.ctx; // only same instance of DSLContext is equal
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/PatternMatchTables.java
+++ b/src/main/java/com/teragrep/pth_06/planner/PatternMatchTables.java
@@ -55,6 +55,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Objects;
 
 import static com.teragrep.pth_06.jooq.generated.bloomdb.Bloomdb.BLOOMDB;
 
@@ -117,5 +118,10 @@ public final class PatternMatchTables {
             return false;
         final PatternMatchTables cast = (PatternMatchTables) object;
         return this.patternMatchCondition.equals(cast.patternMatchCondition) && this.ctx == cast.ctx; // only same instance of DSLContext is equal
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ctx, patternMatchCondition);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/TableFilterTypesFromMetadata.java
+++ b/src/main/java/com/teragrep/pth_06/planner/TableFilterTypesFromMetadata.java
@@ -100,12 +100,10 @@ public final class TableFilterTypesFromMetadata implements TableRecords {
     public boolean equals(final Object object) {
         if (this == object)
             return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
+        if (object == null || object.getClass() != this.getClass())
             return false;
         final TableFilterTypesFromMetadata cast = (TableFilterTypesFromMetadata) object;
-        return this.bloomTermId == cast.bloomTermId && this.table.equals(cast.table) && this.ctx == cast.ctx;
+        return bloomTermId == cast.bloomTermId && table.equals(cast.table) && ctx == cast.ctx;
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/TableFilterTypesFromMetadata.java
+++ b/src/main/java/com/teragrep/pth_06/planner/TableFilterTypesFromMetadata.java
@@ -49,6 +49,8 @@ import org.jooq.*;
 import org.jooq.impl.DSL;
 import org.jooq.types.ULong;
 
+import java.util.Objects;
+
 import static com.teragrep.pth_06.jooq.generated.bloomdb.Bloomdb.BLOOMDB;
 
 /**
@@ -104,5 +106,10 @@ public final class TableFilterTypesFromMetadata implements TableRecords {
             return false;
         final TableFilterTypesFromMetadata cast = (TableFilterTypesFromMetadata) object;
         return this.bloomTermId == cast.bloomTermId && this.table.equals(cast.table) && this.ctx == cast.ctx;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ctx, table, bloomTermId);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/TableFilters.java
+++ b/src/main/java/com/teragrep/pth_06/planner/TableFilters.java
@@ -158,13 +158,12 @@ public final class TableFilters {
     public boolean equals(final Object object) {
         if (this == object)
             return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
+        if (object == null || object.getClass() != this.getClass())
             return false;
         final TableFilters cast = (TableFilters) object;
-        return this.ctx == cast.ctx && this.value.equals(cast.value) && this.table.equals(cast.table)
-                && this.bloomTermId == cast.bloomTermId;
+        return ctx == cast.ctx && value.equals(cast.value) && table.equals(cast.table)
+                && recordsInMetadata.equals(cast.recordsInMetadata)
+                && bloomTermId == cast.bloomTermId;
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/TableFilters.java
+++ b/src/main/java/com/teragrep/pth_06/planner/TableFilters.java
@@ -162,8 +162,7 @@ public final class TableFilters {
             return false;
         final TableFilters cast = (TableFilters) object;
         return ctx == cast.ctx && value.equals(cast.value) && table.equals(cast.table)
-                && recordsInMetadata.equals(cast.recordsInMetadata)
-                && bloomTermId == cast.bloomTermId;
+                && recordsInMetadata.equals(cast.recordsInMetadata) && bloomTermId == cast.bloomTermId;
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/TableFilters.java
+++ b/src/main/java/com/teragrep/pth_06/planner/TableFilters.java
@@ -54,6 +54,7 @@ import org.jooq.types.ULong;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import static com.teragrep.pth_06.jooq.generated.bloomdb.Bloomdb.BLOOMDB;
@@ -164,5 +165,10 @@ public final class TableFilters {
         final TableFilters cast = (TableFilters) object;
         return this.ctx == cast.ctx && this.value.equals(cast.value) && this.table.equals(cast.table)
                 && this.bloomTermId == cast.bloomTermId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ctx, table, bloomTermId, value, recordsInMetadata);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/TokenizedValue.java
+++ b/src/main/java/com/teragrep/pth_06/planner/TokenizedValue.java
@@ -72,16 +72,14 @@ public final class TokenizedValue {
     public boolean equals(final Object object) {
         if (this == object)
             return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
+        if (object == null || object.getClass() != this.getClass())
             return false;
         final TokenizedValue cast = (TokenizedValue) object;
-        return this.value.equals(cast.value);
+        return value.equals(cast.value);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(value);
+        return Objects.hash(value);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/TokenizedValue.java
+++ b/src/main/java/com/teragrep/pth_06/planner/TokenizedValue.java
@@ -51,6 +51,7 @@ import com.teragrep.blf_01.Tokenizer;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 public final class TokenizedValue {
@@ -77,5 +78,10 @@ public final class TokenizedValue {
             return false;
         final TokenizedValue cast = (TokenizedValue) object;
         return this.value.equals(cast.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/CategoryTableCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/CategoryTableCondition.java
@@ -90,12 +90,10 @@ public final class CategoryTableCondition implements QueryCondition {
     public boolean equals(final Object object) {
         if (this == object)
             return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
+        if (object == null || object.getClass() != this.getClass())
             return false;
         final CategoryTableCondition cast = (CategoryTableCondition) object;
-        return this.bloomTermId == cast.bloomTermId && this.comparedTo.equals(cast.comparedTo);
+        return bloomTermId == cast.bloomTermId && comparedTo.equals(cast.comparedTo);
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/CategoryTableCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/CategoryTableCondition.java
@@ -49,6 +49,8 @@ import org.jooq.*;
 import org.jooq.impl.DSL;
 import org.jooq.types.ULong;
 
+import java.util.Objects;
+
 import static org.jooq.impl.SQLDataType.BIGINTUNSIGNED;
 
 /**
@@ -94,5 +96,10 @@ public final class CategoryTableCondition implements QueryCondition {
             return false;
         final CategoryTableCondition cast = (CategoryTableCondition) object;
         return this.bloomTermId == cast.bloomTermId && this.comparedTo.equals(cast.comparedTo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(comparedTo, bloomTermId);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/EarliestCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/EarliestCondition.java
@@ -90,16 +90,14 @@ public final class EarliestCondition implements QueryCondition {
     public boolean equals(final Object object) {
         if (this == object)
             return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
+        if (object == null || object.getClass() != this.getClass())
             return false;
         final EarliestCondition cast = (EarliestCondition) object;
-        return this.value.equals(cast.value);
+        return value.equals(cast.value);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(value);
+        return Objects.hash(value);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/EarliestCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/EarliestCondition.java
@@ -49,6 +49,7 @@ import org.jooq.Condition;
 
 import java.sql.Date;
 import java.time.Instant;
+import java.util.Objects;
 
 import static com.teragrep.pth_06.jooq.generated.journaldb.Journaldb.JOURNALDB;
 
@@ -95,5 +96,10 @@ public final class EarliestCondition implements QueryCondition {
             return false;
         final EarliestCondition cast = (EarliestCondition) object;
         return this.value.equals(cast.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/ElementCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/ElementCondition.java
@@ -53,6 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -139,5 +140,10 @@ public final class ElementCondition implements QueryCondition, BloomQueryConditi
             return false;
         final ElementCondition cast = (ElementCondition) object;
         return this.element.equals(cast.element) && this.config.equals(cast.config);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(element, config);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/ElementCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/ElementCondition.java
@@ -134,12 +134,10 @@ public final class ElementCondition implements QueryCondition, BloomQueryConditi
     public boolean equals(final Object object) {
         if (this == object)
             return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
+        if (object == null || object.getClass() != this.getClass())
             return false;
         final ElementCondition cast = (ElementCondition) object;
-        return this.element.equals(cast.element) && this.config.equals(cast.config);
+        return element.equals(cast.element) && config.equals(cast.config);
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/HostCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/HostCondition.java
@@ -48,6 +48,8 @@ package com.teragrep.pth_06.planner.walker.conditions;
 import com.teragrep.pth_06.planner.StreamDBClient;
 import org.jooq.Condition;
 
+import java.util.Objects;
+
 import static com.teragrep.pth_06.jooq.generated.streamdb.Streamdb.STREAMDB;
 
 public final class HostCondition implements QueryCondition {
@@ -87,5 +89,10 @@ public final class HostCondition implements QueryCondition {
         final HostCondition cast = (HostCondition) object;
         return this.streamQuery == cast.streamQuery && this.value.equals(cast.value)
                 && this.operation.equals(cast.operation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value, operation, streamQuery);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/HostCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/HostCondition.java
@@ -85,8 +85,7 @@ public final class HostCondition implements QueryCondition {
         if (object == null || object.getClass() != this.getClass())
             return false;
         final HostCondition cast = (HostCondition) object;
-        return streamQuery == cast.streamQuery && value.equals(cast.value)
-                && operation.equals(cast.operation);
+        return streamQuery == cast.streamQuery && value.equals(cast.value) && operation.equals(cast.operation);
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/HostCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/HostCondition.java
@@ -82,13 +82,11 @@ public final class HostCondition implements QueryCondition {
     public boolean equals(final Object object) {
         if (this == object)
             return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
+        if (object == null || object.getClass() != this.getClass())
             return false;
         final HostCondition cast = (HostCondition) object;
-        return this.streamQuery == cast.streamQuery && this.value.equals(cast.value)
-                && this.operation.equals(cast.operation);
+        return streamQuery == cast.streamQuery && value.equals(cast.value)
+                && operation.equals(cast.operation);
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/IndexCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/IndexCondition.java
@@ -48,6 +48,8 @@ package com.teragrep.pth_06.planner.walker.conditions;
 import com.teragrep.pth_06.planner.StreamDBClient;
 import org.jooq.Condition;
 
+import java.util.Objects;
+
 import static com.teragrep.pth_06.jooq.generated.streamdb.Streamdb.STREAMDB;
 
 public final class IndexCondition implements QueryCondition {
@@ -88,5 +90,10 @@ public final class IndexCondition implements QueryCondition {
         final IndexCondition cast = (IndexCondition) object;
         return this.streamQuery == cast.streamQuery && this.value.equals(cast.value)
                 && this.operation.equals(cast.operation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value, operation, streamQuery);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/IndexCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/IndexCondition.java
@@ -83,13 +83,11 @@ public final class IndexCondition implements QueryCondition {
     public boolean equals(final Object object) {
         if (this == object)
             return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
+        if (object == null || object.getClass() != this.getClass())
             return false;
         final IndexCondition cast = (IndexCondition) object;
-        return this.streamQuery == cast.streamQuery && this.value.equals(cast.value)
-                && this.operation.equals(cast.operation);
+        return streamQuery == cast.streamQuery && value.equals(cast.value)
+                && operation.equals(cast.operation);
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/IndexCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/IndexCondition.java
@@ -86,8 +86,7 @@ public final class IndexCondition implements QueryCondition {
         if (object == null || object.getClass() != this.getClass())
             return false;
         final IndexCondition cast = (IndexCondition) object;
-        return streamQuery == cast.streamQuery && value.equals(cast.value)
-                && operation.equals(cast.operation);
+        return streamQuery == cast.streamQuery && value.equals(cast.value) && operation.equals(cast.operation);
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/IndexStatementCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/IndexStatementCondition.java
@@ -54,6 +54,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 public final class IndexStatementCondition implements QueryCondition, BloomQueryCondition {
@@ -135,5 +136,10 @@ public final class IndexStatementCondition implements QueryCondition, BloomQuery
             return false;
         final IndexStatementCondition cast = (IndexStatementCondition) object;
         return this.value.equals(cast.value) && this.config.equals(cast.config);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value, config, condition, tableSet);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/IndexStatementCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/IndexStatementCondition.java
@@ -130,12 +130,11 @@ public final class IndexStatementCondition implements QueryCondition, BloomQuery
     public boolean equals(final Object object) {
         if (this == object)
             return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
+        if (object == null || object.getClass() != this.getClass())
             return false;
         final IndexStatementCondition cast = (IndexStatementCondition) object;
-        return this.value.equals(cast.value) && this.config.equals(cast.config);
+        return value.equals(cast.value) && config.equals(cast.config)
+                && condition.equals(cast.condition) && tableSet.equals(cast.tableSet);
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/IndexStatementCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/IndexStatementCondition.java
@@ -133,8 +133,8 @@ public final class IndexStatementCondition implements QueryCondition, BloomQuery
         if (object == null || object.getClass() != this.getClass())
             return false;
         final IndexStatementCondition cast = (IndexStatementCondition) object;
-        return value.equals(cast.value) && config.equals(cast.config)
-                && condition.equals(cast.condition) && tableSet.equals(cast.tableSet);
+        return value.equals(cast.value) && config.equals(cast.config) && condition.equals(cast.condition)
+                && tableSet.equals(cast.tableSet);
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/LatestCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/LatestCondition.java
@@ -87,16 +87,14 @@ public final class LatestCondition implements QueryCondition {
     public boolean equals(final Object object) {
         if (this == object)
             return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
+        if (object == null || object.getClass() != this.getClass())
             return false;
         final LatestCondition cast = (LatestCondition) object;
-        return this.value.equals(cast.value);
+        return value.equals(cast.value);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(value);
+        return Objects.hash(value);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/LatestCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/LatestCondition.java
@@ -49,6 +49,7 @@ import org.jooq.Condition;
 
 import java.sql.Date;
 import java.time.Instant;
+import java.util.Objects;
 
 import static com.teragrep.pth_06.jooq.generated.journaldb.Journaldb.JOURNALDB;
 
@@ -92,5 +93,10 @@ public final class LatestCondition implements QueryCondition {
             return false;
         final LatestCondition cast = (LatestCondition) object;
         return this.value.equals(cast.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/PatternMatchCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/PatternMatchCondition.java
@@ -50,6 +50,8 @@ import com.teragrep.pth_06.planner.TokenizedValue;
 import org.jooq.*;
 import org.jooq.impl.DSL;
 
+import java.util.Objects;
+
 import static com.teragrep.pth_06.jooq.generated.bloomdb.Bloomdb.BLOOMDB;
 
 /**
@@ -88,5 +90,10 @@ public final class PatternMatchCondition implements QueryCondition {
             return false;
         final PatternMatchCondition cast = (PatternMatchCondition) object;
         return this.value.equals(cast.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/PatternMatchCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/PatternMatchCondition.java
@@ -84,16 +84,14 @@ public final class PatternMatchCondition implements QueryCondition {
     public boolean equals(final Object object) {
         if (this == object)
             return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
+        if (object == null || object.getClass() != this.getClass())
             return false;
         final PatternMatchCondition cast = (PatternMatchCondition) object;
-        return this.value.equals(cast.value);
+        return value.equals(cast.value);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(value);
+        return Objects.hash(value);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/SourceTypeCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/SourceTypeCondition.java
@@ -85,8 +85,7 @@ public final class SourceTypeCondition implements QueryCondition {
         if (object == null || object.getClass() != this.getClass())
             return false;
         final SourceTypeCondition cast = (SourceTypeCondition) object;
-        return streamQuery == cast.streamQuery && value.equals(cast.value)
-                && operation.equals(cast.operation);
+        return streamQuery == cast.streamQuery && value.equals(cast.value) && operation.equals(cast.operation);
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/SourceTypeCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/SourceTypeCondition.java
@@ -82,13 +82,11 @@ public final class SourceTypeCondition implements QueryCondition {
     public boolean equals(final Object object) {
         if (this == object)
             return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
+        if (object == null || object.getClass() != this.getClass())
             return false;
         final SourceTypeCondition cast = (SourceTypeCondition) object;
-        return this.streamQuery == cast.streamQuery && this.value.equals(cast.value)
-                && this.operation.equals(cast.operation);
+        return streamQuery == cast.streamQuery && value.equals(cast.value)
+                && operation.equals(cast.operation);
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/SourceTypeCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/SourceTypeCondition.java
@@ -48,6 +48,8 @@ package com.teragrep.pth_06.planner.walker.conditions;
 import com.teragrep.pth_06.planner.StreamDBClient;
 import org.jooq.Condition;
 
+import java.util.Objects;
+
 import static com.teragrep.pth_06.jooq.generated.streamdb.Streamdb.STREAMDB;
 
 public final class SourceTypeCondition implements QueryCondition {
@@ -87,5 +89,10 @@ public final class SourceTypeCondition implements QueryCondition {
         final SourceTypeCondition cast = (SourceTypeCondition) object;
         return this.streamQuery == cast.streamQuery && this.value.equals(cast.value)
                 && this.operation.equals(cast.operation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value, operation, streamQuery);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/ValidElement.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/ValidElement.java
@@ -47,6 +47,8 @@ package com.teragrep.pth_06.planner.walker.conditions;
 
 import org.w3c.dom.Element;
 
+import java.util.Objects;
+
 public final class ValidElement {
 
     private final Element element;
@@ -99,5 +101,10 @@ public final class ValidElement {
         boolean equalOperation = this.element.getAttribute("operation").equals(cast.element.getAttribute("operation"));
         boolean equalValue = this.element.getAttribute("value").equals(cast.element.getAttribute("value"));
         return equalName && equalOperation && equalValue;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(element);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/ValidElement.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/ValidElement.java
@@ -92,19 +92,14 @@ public final class ValidElement {
     public boolean equals(final Object object) {
         if (this == object)
             return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
+        if (object == null || object.getClass() != this.getClass())
             return false;
         final ValidElement cast = (ValidElement) object;
-        boolean equalName = this.element.getTagName().equals(cast.element.getTagName());
-        boolean equalOperation = this.element.getAttribute("operation").equals(cast.element.getAttribute("operation"));
-        boolean equalValue = this.element.getAttribute("value").equals(cast.element.getAttribute("value"));
-        return equalName && equalOperation && equalValue;
+        return Objects.equals(element, cast.element);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(element);
+        return Objects.hash(element);
     }
 }

--- a/src/test/java/com/teragrep/pth_06/config/ConditionConfigTest.java
+++ b/src/test/java/com/teragrep/pth_06/config/ConditionConfigTest.java
@@ -1,0 +1,85 @@
+/*
+ * Teragrep Archive Datasource (pth_06)
+ * Copyright (C) 2021-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.pth_06.config;
+
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.jooq.tools.jdbc.MockConnection;
+import org.jooq.tools.jdbc.MockResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ConditionConfigTest {
+
+    DSLContext ctx = DSL.using(new MockConnection(c -> new MockResult[0]));
+
+    @Test
+    void testEquality() {
+        ConditionConfig cond1 = new ConditionConfig(ctx, false, false);
+        ConditionConfig cond2 = new ConditionConfig(ctx, false, false);
+        Assertions.assertEquals(cond1, cond2);
+    }
+
+    @Test
+    void testNonEquality() {
+        ConditionConfig cond1 = new ConditionConfig(ctx, false, false);
+        ConditionConfig cond2 = new ConditionConfig(ctx, true, false);
+        ConditionConfig cond3 = new ConditionConfig(ctx, false, true);
+        Assertions.assertNotEquals(cond1, cond2);
+        Assertions.assertNotEquals(cond1, cond3);
+    }
+
+    @Test
+    void testHashCode() {
+        ConditionConfig cond1 = new ConditionConfig(ctx, false, false);
+        ConditionConfig cond2 = new ConditionConfig(ctx, false, false);
+        ConditionConfig cond3 = new ConditionConfig(ctx, true, false);
+        ConditionConfig cond4 = new ConditionConfig(ctx, false, true);
+        Assertions.assertEquals(cond1.hashCode(), cond2.hashCode());
+        Assertions.assertNotEquals(cond1.hashCode(), cond3.hashCode());
+        Assertions.assertNotEquals(cond1.hashCode(), cond4.hashCode());
+    }
+}

--- a/src/test/java/com/teragrep/pth_06/config/ConditionConfigTest.java
+++ b/src/test/java/com/teragrep/pth_06/config/ConditionConfigTest.java
@@ -45,7 +45,6 @@
  */
 package com.teragrep.pth_06.config;
 
-import com.teragrep.pth_06.planner.walker.conditions.SourceTypeCondition;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.DSLContext;
 import org.jooq.impl.DSL;
@@ -70,7 +69,7 @@ public class ConditionConfigTest {
         ConditionConfig cond1 = new ConditionConfig(ctx, false, false);
         ConditionConfig cond2 = new ConditionConfig(ctx, true, false);
         ConditionConfig cond3 = new ConditionConfig(ctx, false, true);
-        ConditionConfig cond4 = new ConditionConfig(ctx, false, true , 1L);
+        ConditionConfig cond4 = new ConditionConfig(ctx, false, true, 1L);
         Assertions.assertNotEquals(cond1, cond2);
         Assertions.assertNotEquals(cond1, cond3);
         Assertions.assertNotEquals(cond1, cond4);

--- a/src/test/java/com/teragrep/pth_06/config/ConditionConfigTest.java
+++ b/src/test/java/com/teragrep/pth_06/config/ConditionConfigTest.java
@@ -58,8 +58,8 @@ public class ConditionConfigTest {
 
     @Test
     void testEquality() {
-        ConditionConfig cond1 = new ConditionConfig(ctx, false, false);
-        ConditionConfig cond2 = new ConditionConfig(ctx, false, false);
+        ConditionConfig cond1 = new ConditionConfig(ctx, false, false, 1L);
+        ConditionConfig cond2 = new ConditionConfig(ctx, false, false, 1L);
         Assertions.assertEquals(cond1, cond2);
     }
 
@@ -68,8 +68,10 @@ public class ConditionConfigTest {
         ConditionConfig cond1 = new ConditionConfig(ctx, false, false);
         ConditionConfig cond2 = new ConditionConfig(ctx, true, false);
         ConditionConfig cond3 = new ConditionConfig(ctx, false, true);
+        ConditionConfig cond4 = new ConditionConfig(ctx, false, true , 1L);
         Assertions.assertNotEquals(cond1, cond2);
         Assertions.assertNotEquals(cond1, cond3);
+        Assertions.assertNotEquals(cond1, cond4);
     }
 
     @Test
@@ -78,8 +80,10 @@ public class ConditionConfigTest {
         ConditionConfig cond2 = new ConditionConfig(ctx, false, false);
         ConditionConfig cond3 = new ConditionConfig(ctx, true, false);
         ConditionConfig cond4 = new ConditionConfig(ctx, false, true);
+        ConditionConfig cond5 = new ConditionConfig(ctx, false, false, 1L);
         Assertions.assertEquals(cond1.hashCode(), cond2.hashCode());
         Assertions.assertNotEquals(cond1.hashCode(), cond3.hashCode());
         Assertions.assertNotEquals(cond1.hashCode(), cond4.hashCode());
+        Assertions.assertNotEquals(cond1.hashCode(), cond5.hashCode());
     }
 }

--- a/src/test/java/com/teragrep/pth_06/config/ConditionConfigTest.java
+++ b/src/test/java/com/teragrep/pth_06/config/ConditionConfigTest.java
@@ -45,6 +45,8 @@
  */
 package com.teragrep.pth_06.config;
 
+import com.teragrep.pth_06.planner.walker.conditions.SourceTypeCondition;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.DSLContext;
 import org.jooq.impl.DSL;
 import org.jooq.tools.jdbc.MockConnection;
@@ -85,5 +87,10 @@ public class ConditionConfigTest {
         Assertions.assertNotEquals(cond1.hashCode(), cond3.hashCode());
         Assertions.assertNotEquals(cond1.hashCode(), cond4.hashCode());
         Assertions.assertNotEquals(cond1.hashCode(), cond5.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(ConditionConfig.class).verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/CategoryTableImplTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/CategoryTableImplTest.java
@@ -110,7 +110,7 @@ public class CategoryTableImplTest {
     }
 
     @BeforeEach
-    void createTargetTable() {
+    public void createTargetTable() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();
             conn.prepareStatement("USE BLOOMDB").execute();
@@ -125,7 +125,7 @@ public class CategoryTableImplTest {
     }
 
     @AfterAll
-    void tearDown() {
+    public void tearDown() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("DROP ALL OBJECTS").execute(); //h2 clear database
             conn.close();

--- a/src/test/java/com/teragrep/pth_06/planner/CategoryTableImplTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/CategoryTableImplTest.java
@@ -304,6 +304,31 @@ public class CategoryTableImplTest {
         Assertions.assertNotEquals(table1, table2);
     }
 
+    @Test
+    public void testHashCode() {
+        fillTargetTable();
+        DSLContext ctx = DSL.using(conn);
+        Table<?> target1 = ctx
+                .meta()
+                .filterSchemas(s -> s.getName().equals("bloomdb"))
+                .filterTables(t -> !t.getName().equals("filtertype"))
+                .getTables()
+                .get(0);
+        Table<?> target2 = ctx
+                .meta()
+                .filterSchemas(s -> s.getName().equals("bloomdb"))
+                .filterTables(t -> !t.getName().equals("filtertype"))
+                .getTables()
+                .get(0);
+        CategoryTableImpl table1 = new CategoryTableImpl(ctx, target1, 1L, "one");
+        CategoryTableImpl table2 = new CategoryTableImpl(ctx, target2, 1L, "one");
+        CategoryTableImpl notEq1 = new CategoryTableImpl(ctx, target1, 2L, "one");
+        CategoryTableImpl notEq2 = new CategoryTableImpl(ctx, target1, 1L, "two");
+        Assertions.assertEquals(table1.hashCode(), table2.hashCode());
+        Assertions.assertNotEquals(table1.hashCode(), notEq1.hashCode());
+        Assertions.assertNotEquals(table1.hashCode(), notEq2.hashCode());
+    }
+
     void fillTargetTable() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();

--- a/src/test/java/com/teragrep/pth_06/planner/CategoryTableImplTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/CategoryTableImplTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth_06.planner;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.spark.util.sketch.BloomFilter;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
@@ -327,6 +328,17 @@ public class CategoryTableImplTest {
         Assertions.assertEquals(table1.hashCode(), table2.hashCode());
         Assertions.assertNotEquals(table1.hashCode(), notEq1.hashCode());
         Assertions.assertNotEquals(table1.hashCode(), notEq2.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(CategoryTableImpl.class)
+                .withNonnullFields("ctx")
+                .withNonnullFields("originTable")
+                .withNonnullFields("bloomTermId")
+                .withNonnullFields("tableCondition")
+                .withNonnullFields("tableFilters")
+                .verify();
     }
 
     void fillTargetTable() {

--- a/src/test/java/com/teragrep/pth_06/planner/CategoryTableImplTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/CategoryTableImplTest.java
@@ -332,7 +332,8 @@ public class CategoryTableImplTest {
 
     @Test
     public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(CategoryTableImpl.class)
+        EqualsVerifier
+                .forClass(CategoryTableImpl.class)
                 .withNonnullFields("ctx")
                 .withNonnullFields("originTable")
                 .withNonnullFields("bloomTermId")

--- a/src/test/java/com/teragrep/pth_06/planner/PatternMatchTablesTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/PatternMatchTablesTest.java
@@ -76,7 +76,7 @@ public class PatternMatchTablesTest {
     final Connection conn = Assertions.assertDoesNotThrow(() -> DriverManager.getConnection(url, userName, password));
 
     @BeforeAll
-    void setup() {
+    public void setup() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();
             conn.prepareStatement("USE BLOOMDB").execute();
@@ -119,7 +119,7 @@ public class PatternMatchTablesTest {
     }
 
     @AfterAll
-    void tearDown() {
+    public void tearDown() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("DROP ALL OBJECTS").execute(); //h2 clear database
             conn.close();

--- a/src/test/java/com/teragrep/pth_06/planner/PatternMatchTablesTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/PatternMatchTablesTest.java
@@ -210,7 +210,8 @@ public class PatternMatchTablesTest {
 
     @Test
     public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(PatternMatchTables.class)
+        EqualsVerifier
+                .forClass(PatternMatchTables.class)
                 .withNonnullFields("ctx")
                 .withNonnullFields("patternMatchCondition")
                 .verify();

--- a/src/test/java/com/teragrep/pth_06/planner/PatternMatchTablesTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/PatternMatchTablesTest.java
@@ -197,6 +197,16 @@ public class PatternMatchTablesTest {
         Assertions.assertNotEquals(eq2, eq1);
     }
 
+    @Test
+    public void hashCodeTest() {
+        DSLContext ctx = DSL.using(conn);
+        PatternMatchTables eq1 = new PatternMatchTables(ctx, "testinput");
+        PatternMatchTables eq2 = new PatternMatchTables(ctx, "testinput");
+        PatternMatchTables notEq = new PatternMatchTables(ctx, "somethingelse");
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
+    }
+
     private void writeFilter(String tableName, int filterId) {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();

--- a/src/test/java/com/teragrep/pth_06/planner/PatternMatchTablesTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/PatternMatchTablesTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth_06.planner;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.spark.util.sketch.BloomFilter;
 import org.jooq.DSLContext;
 import org.jooq.Named;
@@ -205,6 +206,14 @@ public class PatternMatchTablesTest {
         PatternMatchTables notEq = new PatternMatchTables(ctx, "somethingelse");
         Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
         Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(PatternMatchTables.class)
+                .withNonnullFields("ctx")
+                .withNonnullFields("patternMatchCondition")
+                .verify();
     }
 
     private void writeFilter(String tableName, int filterId) {

--- a/src/test/java/com/teragrep/pth_06/planner/TableFilterTypesFromMetadataResultTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/TableFilterTypesFromMetadataResultTest.java
@@ -64,7 +64,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class TableFilterTypesFromMetadataResultTest {
+public class TableFilterTypesFromMetadataResultTest {
 
     final String url = "jdbc:h2:mem:test;MODE=MariaDB;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE";
     final String userName = "sa";
@@ -104,7 +104,7 @@ class TableFilterTypesFromMetadataResultTest {
     }
 
     @BeforeEach
-    void createTargetTable() {
+    public void createTargetTable() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();
             conn.prepareStatement("USE BLOOMDB").execute();
@@ -119,7 +119,7 @@ class TableFilterTypesFromMetadataResultTest {
     }
 
     @AfterAll
-    void tearDown() {
+    public void tearDown() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("DROP ALL OBJECTS").execute(); //h2 clear database
             conn.close();
@@ -127,7 +127,7 @@ class TableFilterTypesFromMetadataResultTest {
     }
 
     @Test
-    void testNoFilterTypes() {
+    public void testNoFilterTypes() {
         DSLContext ctx = DSL.using(conn);
         Table<?> table = ctx
                 .meta()
@@ -141,7 +141,7 @@ class TableFilterTypesFromMetadataResultTest {
     }
 
     @Test
-    void testOneFilterType() {
+    public void testOneFilterType() {
         insertSizedFilterIntoTargetTable(1);
         DSLContext ctx = DSL.using(conn);
         Table<?> table = ctx
@@ -158,7 +158,7 @@ class TableFilterTypesFromMetadataResultTest {
     }
 
     @Test
-    void testMultipleFilterTypes() {
+    public void testMultipleFilterTypes() {
         insertSizedFilterIntoTargetTable(1);
         insertSizedFilterIntoTargetTable(2);
         DSLContext ctx = DSL.using(conn);
@@ -234,7 +234,7 @@ class TableFilterTypesFromMetadataResultTest {
                 .verify();
     }
 
-    void insertSizedFilterIntoTargetTable(int filterTypeId) {
+    private void insertSizedFilterIntoTargetTable(int filterTypeId) {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();
             conn.prepareStatement("USE BLOOMDB").execute();

--- a/src/test/java/com/teragrep/pth_06/planner/TableFilterTypesFromMetadataResultTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/TableFilterTypesFromMetadataResultTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth_06.planner;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.spark.util.sketch.BloomFilter;
 import org.jooq.DSLContext;
 import org.jooq.Record;
@@ -221,6 +222,15 @@ class TableFilterTypesFromMetadataResultTest {
         TableFilterTypesFromMetadata notEq = new TableFilterTypesFromMetadata(ctx, table, 1L);
         Assertions.assertEquals(result1.hashCode(), result2.hashCode());
         Assertions.assertNotEquals(result1.hashCode(), notEq.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(TableFilterTypesFromMetadata.class)
+                .withNonnullFields("ctx")
+                .withNonnullFields("table")
+                .withNonnullFields("bloomTermId")
+                .verify();
     }
 
     void insertSizedFilterIntoTargetTable(int filterTypeId) {

--- a/src/test/java/com/teragrep/pth_06/planner/TableFilterTypesFromMetadataResultTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/TableFilterTypesFromMetadataResultTest.java
@@ -226,7 +226,8 @@ class TableFilterTypesFromMetadataResultTest {
 
     @Test
     public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(TableFilterTypesFromMetadata.class)
+        EqualsVerifier
+                .forClass(TableFilterTypesFromMetadata.class)
                 .withNonnullFields("ctx")
                 .withNonnullFields("table")
                 .withNonnullFields("bloomTermId")

--- a/src/test/java/com/teragrep/pth_06/planner/TableFilterTypesFromMetadataResultTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/TableFilterTypesFromMetadataResultTest.java
@@ -207,6 +207,22 @@ class TableFilterTypesFromMetadataResultTest {
         Assertions.assertNotEquals(result1, result3);
     }
 
+    @Test
+    public void testHashCode() {
+        DSLContext ctx = DSL.using(conn);
+        Table<?> table = ctx
+                .meta()
+                .filterSchemas(s -> s.getName().equals("bloomdb"))
+                .filterTables(t -> !t.getName().equals("filtertype"))
+                .getTables()
+                .get(0);
+        TableFilterTypesFromMetadata result1 = new TableFilterTypesFromMetadata(ctx, table, 0L);
+        TableFilterTypesFromMetadata result2 = new TableFilterTypesFromMetadata(ctx, table, 0L);
+        TableFilterTypesFromMetadata notEq = new TableFilterTypesFromMetadata(ctx, table, 1L);
+        Assertions.assertEquals(result1.hashCode(), result2.hashCode());
+        Assertions.assertNotEquals(result1.hashCode(), notEq.hashCode());
+    }
+
     void insertSizedFilterIntoTargetTable(int filterTypeId) {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();

--- a/src/test/java/com/teragrep/pth_06/planner/TableFiltersTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/TableFiltersTest.java
@@ -222,7 +222,8 @@ class TableFiltersTest {
 
     @Test
     public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(TableFilters.class)
+        EqualsVerifier
+                .forClass(TableFilters.class)
                 .withNonnullFields("ctx")
                 .withNonnullFields("table")
                 .withNonnullFields("bloomTermId")

--- a/src/test/java/com/teragrep/pth_06/planner/TableFiltersTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/TableFiltersTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth_06.planner;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.spark.util.sketch.BloomFilter;
 import org.jooq.DSLContext;
 import org.jooq.Table;
@@ -217,6 +218,17 @@ class TableFiltersTest {
         Assertions.assertEquals(filter1.hashCode(), filter2.hashCode());
         Assertions.assertNotEquals(filter1.hashCode(), notEq1.hashCode());
         Assertions.assertNotEquals(filter1.hashCode(), notEq2.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(TableFilters.class)
+                .withNonnullFields("ctx")
+                .withNonnullFields("table")
+                .withNonnullFields("bloomTermId")
+                .withNonnullFields("value")
+                .withNonnullFields("recordsInMetadata")
+                .verify();
     }
 
     void fillTargetTable() {

--- a/src/test/java/com/teragrep/pth_06/planner/TableFiltersTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/TableFiltersTest.java
@@ -62,7 +62,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class TableFiltersTest {
+public class TableFiltersTest {
 
     final String url = "jdbc:h2:mem:test;MODE=MariaDB;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE";
     final String userName = "sa";
@@ -102,7 +102,7 @@ class TableFiltersTest {
     }
 
     @BeforeEach
-    void createTargetTable() {
+    public void createTargetTable() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();
             conn.prepareStatement("USE BLOOMDB").execute();
@@ -117,7 +117,7 @@ class TableFiltersTest {
     }
 
     @AfterAll
-    void tearDown() {
+    public void tearDown() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("DROP ALL OBJECTS").execute(); //h2 clear database
             conn.close();

--- a/src/test/java/com/teragrep/pth_06/planner/TableFiltersTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/TableFiltersTest.java
@@ -200,6 +200,25 @@ class TableFiltersTest {
         Assertions.assertNotEquals(filter1, filter3);
     }
 
+    @Test
+    public void testHashCode() {
+        fillTargetTable();
+        DSLContext ctx = DSL.using(conn);
+        Table<?> table = ctx
+                .meta()
+                .filterSchemas(s -> s.getName().equals("bloomdb"))
+                .filterTables(t -> !t.getName().equals("filtertype"))
+                .getTables()
+                .get(0);
+        TableFilters filter1 = new TableFilters(ctx, table, 0L, "test");
+        TableFilters filter2 = new TableFilters(ctx, table, 0L, "test");
+        TableFilters notEq1 = new TableFilters(ctx, table, 0L, "notTest");
+        TableFilters notEq2 = new TableFilters(ctx, table, 1L, "test");
+        Assertions.assertEquals(filter1.hashCode(), filter2.hashCode());
+        Assertions.assertNotEquals(filter1.hashCode(), notEq1.hashCode());
+        Assertions.assertNotEquals(filter1.hashCode(), notEq2.hashCode());
+    }
+
     void fillTargetTable() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();

--- a/src/test/java/com/teragrep/pth_06/planner/TokenizedValueTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/TokenizedValueTest.java
@@ -99,8 +99,6 @@ class TokenizedValueTest {
 
     @Test
     public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(TokenizedValue.class)
-                .withNonnullFields("value")
-                .verify();
+        EqualsVerifier.forClass(TokenizedValue.class).withNonnullFields("value").verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/TokenizedValueTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/TokenizedValueTest.java
@@ -53,10 +53,10 @@ import org.junit.jupiter.api.Test;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-class TokenizedValueTest {
+public class TokenizedValueTest {
 
     @Test
-    void testTokenization() {
+    public void testTokenization() {
         TokenizedValue result = new TokenizedValue("test.nest");
         Set<String> tokens = result.tokens().stream().map(Token::toString).collect(Collectors.toSet());
         Assertions.assertEquals("test.nest", result.value);
@@ -70,7 +70,7 @@ class TokenizedValueTest {
     }
 
     @Test
-    void testEquality() {
+    public void testEquality() {
         TokenizedValue value1 = new TokenizedValue("test");
         TokenizedValue value2 = new TokenizedValue("test");
         Assertions.assertEquals(value1, value2);
@@ -80,7 +80,7 @@ class TokenizedValueTest {
     }
 
     @Test
-    void testNotEquals() {
+    public void testNotEquals() {
         TokenizedValue value1 = new TokenizedValue("test");
         TokenizedValue value2 = new TokenizedValue("nest");
         Assertions.assertNotEquals(value1, value2);
@@ -89,7 +89,7 @@ class TokenizedValueTest {
     }
 
     @Test
-    void testHashCode() {
+    public void testHashCode() {
         TokenizedValue value1 = new TokenizedValue("test");
         TokenizedValue value2 = new TokenizedValue("test");
         TokenizedValue notEq = new TokenizedValue("nest");

--- a/src/test/java/com/teragrep/pth_06/planner/TokenizedValueTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/TokenizedValueTest.java
@@ -46,6 +46,7 @@
 package com.teragrep.pth_06.planner;
 
 import com.teragrep.blf_01.Token;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -94,5 +95,12 @@ class TokenizedValueTest {
         TokenizedValue notEq = new TokenizedValue("nest");
         Assertions.assertEquals(value1.hashCode(), value2.hashCode());
         Assertions.assertNotEquals(value1.hashCode(), notEq.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(TokenizedValue.class)
+                .withNonnullFields("value")
+                .verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/TokenizedValueTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/TokenizedValueTest.java
@@ -86,4 +86,13 @@ class TokenizedValueTest {
         Assertions.assertNotEquals(value2, value1);
         Assertions.assertNotEquals(value1, null);
     }
+
+    @Test
+    void testHashCode() {
+        TokenizedValue value1 = new TokenizedValue("test");
+        TokenizedValue value2 = new TokenizedValue("test");
+        TokenizedValue notEq = new TokenizedValue("nest");
+        Assertions.assertEquals(value1.hashCode(), value2.hashCode());
+        Assertions.assertNotEquals(value1.hashCode(), notEq.hashCode());
+    }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/CategoryTableConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/CategoryTableConditionTest.java
@@ -67,7 +67,7 @@ import java.util.List;
  * @see org.jooq.QueryPart
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class CategoryTableConditionTest {
+public class CategoryTableConditionTest {
 
     final String url = "jdbc:h2:mem:test;MODE=MariaDB;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE";
     final String userName = "sa";
@@ -107,7 +107,7 @@ class CategoryTableConditionTest {
     }
 
     @BeforeEach
-    void createTargetTable() {
+    public void createTargetTable() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();
             conn.prepareStatement("USE BLOOMDB").execute();
@@ -122,7 +122,7 @@ class CategoryTableConditionTest {
     }
 
     @AfterAll
-    void tearDown() {
+    public void tearDown() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("DROP ALL OBJECTS").execute(); //h2 clear database
             conn.close();
@@ -130,7 +130,7 @@ class CategoryTableConditionTest {
     }
 
     @Test
-    void testCondition() {
+    public void testCondition() {
         fillTargetTable();
         DSLContext ctx = DSL.using(conn);
         Table<?> target1 = ctx
@@ -149,7 +149,7 @@ class CategoryTableConditionTest {
     }
 
     @Test
-    void testBloomTermId() {
+    public void testBloomTermId() {
         fillTargetTable();
         DSLContext ctx = DSL.using(conn);
         Table<?> target1 = ctx

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/CategoryTableConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/CategoryTableConditionTest.java
@@ -200,6 +200,25 @@ class CategoryTableConditionTest {
         Assertions.assertNotEquals(cond1, cond3);
     }
 
+    @Test
+    public void testHashCode() {
+        fillTargetTable();
+        DSLContext ctx = DSL.using(conn);
+        Table<?> target1 = ctx
+                .meta()
+                .filterSchemas(s -> s.getName().equals("bloomdb"))
+                .filterTables(t -> !t.getName().equals("filtertype"))
+                .getTables()
+                .get(0);
+        CategoryTableCondition cond1 = new CategoryTableCondition(target1, 0L);
+        CategoryTableCondition condEq = new CategoryTableCondition(target1, 0L);
+        CategoryTableCondition cond2 = new CategoryTableCondition(target1, 1L);
+        CategoryTableCondition cond3 = new CategoryTableCondition(null, 1L);
+        Assertions.assertEquals(cond1.hashCode(), condEq.hashCode());
+        Assertions.assertNotEquals(cond1.hashCode(), cond2.hashCode());
+        Assertions.assertNotEquals(cond1.hashCode(), cond3.hashCode());
+    }
+
     void fillTargetTable() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/CategoryTableConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/CategoryTableConditionTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.spark.util.sketch.BloomFilter;
 import org.jooq.DSLContext;
 import org.jooq.Table;
@@ -62,7 +63,7 @@ import java.util.List;
 /**
  * Comparing Condition equality using toString() since jooq Condition uses just toString() to check for equality.
  * inherited from QueryPart
- * 
+ *
  * @see org.jooq.QueryPart
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -217,6 +218,14 @@ class CategoryTableConditionTest {
         Assertions.assertEquals(cond1.hashCode(), condEq.hashCode());
         Assertions.assertNotEquals(cond1.hashCode(), cond2.hashCode());
         Assertions.assertNotEquals(cond1.hashCode(), cond3.hashCode());
+    }
+
+    @Test
+    public void equalsverifier() {
+        EqualsVerifier.forClass(CategoryTableCondition.class)
+                .withNonnullFields("bloomTermId")
+                .withNonnullFields("comparedTo")
+                .verify();
     }
 
     void fillTargetTable() {

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/CategoryTableConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/CategoryTableConditionTest.java
@@ -222,7 +222,8 @@ class CategoryTableConditionTest {
 
     @Test
     public void equalsverifier() {
-        EqualsVerifier.forClass(CategoryTableCondition.class)
+        EqualsVerifier
+                .forClass(CategoryTableCondition.class)
                 .withNonnullFields("bloomTermId")
                 .withNonnullFields("comparedTo")
                 .verify();

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
@@ -59,7 +59,7 @@ import org.junit.jupiter.api.Test;
 public class EarliestConditionTest {
 
     @Test
-    void conditionTest() {
+    public void conditionTest() {
         String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" >= date '1970-01-01'\n"
                 + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 0)\n"
                 + ")";
@@ -68,21 +68,21 @@ public class EarliestConditionTest {
     }
 
     @Test
-    void equalsTest() {
+    public void equalsTest() {
         EarliestCondition eq1 = new EarliestCondition("946677600");
         EarliestCondition eq2 = new EarliestCondition("946677600");
         Assertions.assertEquals(eq1, eq2);
     }
 
     @Test
-    void notEqualsTest() {
+    public void notEqualsTest() {
         EarliestCondition eq1 = new EarliestCondition("946677600");
         EarliestCondition notEq = new EarliestCondition("1000");
         Assertions.assertNotEquals(eq1, notEq);
     }
 
     @Test
-    void hashCodeTest() {
+    public void hashCodeTest() {
         EarliestCondition eq1 = new EarliestCondition("946677600");
         EarliestCondition eq2 = new EarliestCondition("946677600");
         EarliestCondition notEq = new EarliestCondition("1000");

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
@@ -45,7 +45,6 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
-import com.teragrep.pth_06.planner.CategoryTableImpl;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
@@ -93,8 +92,6 @@ public class EarliestConditionTest {
 
     @Test
     public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(EarliestCondition.class)
-                .withNonnullFields("value")
-                .verify();
+        EqualsVerifier.forClass(EarliestCondition.class).withNonnullFields("value").verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
@@ -45,6 +45,8 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
+import com.teragrep.pth_06.planner.CategoryTableImpl;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -87,5 +89,12 @@ public class EarliestConditionTest {
         EarliestCondition notEq = new EarliestCondition("1000");
         Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
         Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(EarliestCondition.class)
+                .withNonnullFields("value")
+                .verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
@@ -69,7 +69,6 @@ public class EarliestConditionTest {
     @Test
     void equalsTest() {
         EarliestCondition eq1 = new EarliestCondition("946677600");
-        eq1.condition();
         EarliestCondition eq2 = new EarliestCondition("946677600");
         Assertions.assertEquals(eq1, eq2);
     }
@@ -79,5 +78,14 @@ public class EarliestConditionTest {
         EarliestCondition eq1 = new EarliestCondition("946677600");
         EarliestCondition notEq = new EarliestCondition("1000");
         Assertions.assertNotEquals(eq1, notEq);
+    }
+
+    @Test
+    void hashCodeTest() {
+        EarliestCondition eq1 = new EarliestCondition("946677600");
+        EarliestCondition eq2 = new EarliestCondition("946677600");
+        EarliestCondition notEq = new EarliestCondition("1000");
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ElementConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ElementConditionTest.java
@@ -46,7 +46,6 @@
 package com.teragrep.pth_06.planner.walker.conditions;
 
 import com.teragrep.pth_06.config.ConditionConfig;
-import com.teragrep.pth_06.planner.CategoryTableImpl;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
@@ -263,7 +262,8 @@ class ElementConditionTest {
 
     @Test
     public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(ElementCondition.class)
+        EqualsVerifier
+                .forClass(ElementCondition.class)
                 .withNonnullFields("element")
                 .withNonnullFields("config")
                 .verify();

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ElementConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ElementConditionTest.java
@@ -66,7 +66,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
  * 
  * @see org.jooq.QueryPart
  */
-class ElementConditionTest {
+public class ElementConditionTest {
 
     final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     final Document document = Assertions.assertDoesNotThrow(() -> factory.newDocumentBuilder().newDocument());
@@ -75,7 +75,7 @@ class ElementConditionTest {
     final ConditionConfig streamConfig = new ConditionConfig(mockCtx, true);
 
     @Test
-    void testStreamTags() {
+    public void testStreamTags() {
         String[] streamTags = {
                 "index", "host", "sourcetype"
         };
@@ -92,7 +92,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void testProvidedElementMissingValue() {
+    public void testProvidedElementMissingValue() {
         Element element = document.createElement("test");
         element.setAttribute("operation", "EQUALS");
         ElementCondition elementCondition = new ElementCondition(element, config);
@@ -102,7 +102,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void testProvidedElementMissingOperation() {
+    public void testProvidedElementMissingOperation() {
         Element element = document.createElement("test");
         element.setAttribute("value", "1000");
         ElementCondition elementCondition = new ElementCondition(element, config);
@@ -112,7 +112,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void testIsIndexStatement() {
+    public void testIsIndexStatement() {
         Element element = document.createElement("indexstatement");
         element.setAttribute("value", "searchTerm");
         element.setAttribute("operation", "EQUALS");
@@ -131,7 +131,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void testIndexStatementWithBadConnection() {
+    public void testIndexStatementWithBadConnection() {
         Element element = document.createElement("indexstatement");
         element.setAttribute("value", "searchTerm");
         element.setAttribute("operation", "EQUALS");
@@ -141,7 +141,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void testTimeQualifiers() {
+    public void testTimeQualifiers() {
         String[] tags = {
                 "earliest", "latest", "index_earliest", "index_latest"
         };
@@ -158,7 +158,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void testInvalidStreamTags() {
+    public void testInvalidStreamTags() {
         String[] tags = {
                 "earliest", "latest", "index_earliest", "index_latest", "indexstatement"
         };
@@ -175,7 +175,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void invalidElementNameTest() {
+    public void invalidElementNameTest() {
         Element element = document.createElement("test");
         element.setAttribute("value", "1000");
         element.setAttribute("operation", "EQUALS");
@@ -189,7 +189,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void equalsTest() {
+    public void equalsTest() {
         Element element = document.createElement("index");
         element.setAttribute("value", "f17");
         element.setAttribute("operation", "EQUALS");
@@ -200,7 +200,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void notEqualsTest() {
+    public void notEqualsTest() {
         Element element = document.createElement("index");
         element.setAttribute("value", "f17");
         element.setAttribute("operation", "EQUALS");
@@ -216,7 +216,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void notEqualsDifferentConfigTest() {
+    public void notEqualsDifferentConfigTest() {
         Element element = document.createElement("index");
         element.setAttribute("value", "f17");
         element.setAttribute("operation", "EQUALS");
@@ -230,7 +230,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void notEqualsDifferentConnectionTest() {
+    public void notEqualsDifferentConnectionTest() {
         Element element = document.createElement("index");
         element.setAttribute("value", "f17");
         element.setAttribute("operation", "EQUALS");
@@ -246,7 +246,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void testHashCode() {
+    public void testHashCode() {
         Element element = document.createElement("index");
         element.setAttribute("value", "f17");
         element.setAttribute("operation", "EQUALS");

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ElementConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ElementConditionTest.java
@@ -46,6 +46,8 @@
 package com.teragrep.pth_06.planner.walker.conditions;
 
 import com.teragrep.pth_06.config.ConditionConfig;
+import com.teragrep.pth_06.planner.CategoryTableImpl;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
@@ -257,5 +259,13 @@ class ElementConditionTest {
         ElementCondition notEq = new ElementCondition(element2, config);
         Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
         Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(ElementCondition.class)
+                .withNonnullFields("element")
+                .withNonnullFields("config")
+                .verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ElementConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ElementConditionTest.java
@@ -243,4 +243,19 @@ class ElementConditionTest {
         ElementCondition notEq = new ElementCondition(element, cfg2);
         Assertions.assertNotEquals(eq, notEq);
     }
+
+    @Test
+    void testHashCode() {
+        Element element = document.createElement("index");
+        element.setAttribute("value", "f17");
+        element.setAttribute("operation", "EQUALS");
+        Element element2 = document.createElement("source");
+        element.setAttribute("value", "f17");
+        element.setAttribute("operation", "EQUALS");
+        ElementCondition eq1 = new ElementCondition(element, config);
+        ElementCondition eq2 = new ElementCondition(element, config);
+        ElementCondition notEq = new ElementCondition(element2, config);
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
+    }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/HostConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/HostConditionTest.java
@@ -45,6 +45,8 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
+import com.teragrep.pth_06.planner.CategoryTableImpl;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -114,5 +116,14 @@ public class HostConditionTest {
         Assertions.assertEquals(eq3.hashCode(), eq4.hashCode());
         Assertions.assertNotEquals(eq1.hashCode(), eq4.hashCode());
         Assertions.assertNotEquals(eq1.hashCode(), eq5.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(HostCondition.class)
+                .withNonnullFields("value")
+                .withNonnullFields("operation")
+                .withNonnullFields("streamQuery")
+                .verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/HostConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/HostConditionTest.java
@@ -45,7 +45,6 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
-import com.teragrep.pth_06.planner.CategoryTableImpl;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
@@ -120,7 +119,8 @@ public class HostConditionTest {
 
     @Test
     public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(HostCondition.class)
+        EqualsVerifier
+                .forClass(HostCondition.class)
                 .withNonnullFields("value")
                 .withNonnullFields("operation")
                 .withNonnullFields("streamQuery")

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/HostConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/HostConditionTest.java
@@ -59,7 +59,7 @@ import org.junit.jupiter.api.Test;
 public class HostConditionTest {
 
     @Test
-    void conditionTest() {
+    public void conditionTest() {
         HostCondition elementCondition = new HostCondition("f17", "EQUALS", false);
         HostCondition streamElementCondition = new HostCondition("f17", "EQUALS", true);
         String e = "\"getArchivedObjects_filter_table\".\"host\" like 'f17'";
@@ -71,7 +71,7 @@ public class HostConditionTest {
     }
 
     @Test
-    void negationTest() {
+    public void negationTest() {
         HostCondition elementCondition = new HostCondition("f17", "NOT_EQUALS", false);
         HostCondition streamElementCondition = new HostCondition("f17", "NOT_EQUALS", true);
         String e = "not (\"getArchivedObjects_filter_table\".\"host\" like 'f17')";
@@ -83,7 +83,7 @@ public class HostConditionTest {
     }
 
     @Test
-    void equalsTest() {
+    public void equalsTest() {
         HostCondition eq1 = new HostCondition("946677600", "EQUALS", false);
         eq1.condition();
         HostCondition eq2 = new HostCondition("946677600", "EQUALS", false);
@@ -95,7 +95,7 @@ public class HostConditionTest {
     }
 
     @Test
-    void notEqualsTest() {
+    public void notEqualsTest() {
         HostCondition eq1 = new HostCondition("946677600", "EQUALS", false);
         HostCondition notEq = new HostCondition("1000", "EQUALS", false);
         HostCondition notEq2 = new HostCondition("946677600", "EQUALS", true);
@@ -105,7 +105,7 @@ public class HostConditionTest {
     }
 
     @Test
-    void hashCodeTest() {
+    public void hashCodeTest() {
         HostCondition eq1 = new HostCondition("946677600", "EQUALS", false);
         HostCondition eq2 = new HostCondition("946677600", "EQUALS", false);
         HostCondition eq3 = new HostCondition("946677600", "EQUALS", true);

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/HostConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/HostConditionTest.java
@@ -102,4 +102,17 @@ public class HostConditionTest {
         Assertions.assertNotEquals(eq1, notEq2);
         Assertions.assertNotEquals(notEq, notEq2);
     }
+
+    @Test
+    void hashCodeTest() {
+        HostCondition eq1 = new HostCondition("946677600", "EQUALS", false);
+        HostCondition eq2 = new HostCondition("946677600", "EQUALS", false);
+        HostCondition eq3 = new HostCondition("946677600", "EQUALS", true);
+        HostCondition eq4 = new HostCondition("946677600", "EQUALS", true);
+        HostCondition eq5 = new HostCondition("12344", "EQUALS", false);
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertEquals(eq3.hashCode(), eq4.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), eq4.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), eq5.hashCode());
+    }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexConditionTest.java
@@ -98,4 +98,15 @@ public class IndexConditionTest {
         Assertions.assertNotEquals(eq1, notEq2);
         Assertions.assertNotEquals(notEq, notEq2);
     }
+
+    @Test
+    void hashCodeTest() {
+        IndexCondition eq1 = new IndexCondition("946677600", "EQUALS", false);
+        IndexCondition eq2 = new IndexCondition("946677600", "EQUALS", false);
+        IndexCondition eq3 = new IndexCondition("946677600", "EQUALS", true);
+        IndexCondition eq4 = new IndexCondition("946677600", "EQUALS", true);
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertEquals(eq3.hashCode(), eq4.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), eq4.hashCode());
+    }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexConditionTest.java
@@ -45,7 +45,6 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
-import com.teragrep.pth_06.planner.CategoryTableImpl;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
@@ -114,7 +113,8 @@ public class IndexConditionTest {
 
     @Test
     public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(IndexCondition.class)
+        EqualsVerifier
+                .forClass(IndexCondition.class)
                 .withNonnullFields("value")
                 .withNonnullFields("operation")
                 .withNonnullFields("streamQuery")

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexConditionTest.java
@@ -59,7 +59,7 @@ import org.junit.jupiter.api.Test;
 public class IndexConditionTest {
 
     @Test
-    void conditionTest() {
+    public void conditionTest() {
         String e = "\"getArchivedObjects_filter_table\".\"directory\" like 'f17'";
         String eStream = "\"streamdb\".\"stream\".\"directory\" like 'f17'";
         Condition elementCondition = new IndexCondition("f17", "EQUALS", false).condition();
@@ -69,7 +69,7 @@ public class IndexConditionTest {
     }
 
     @Test
-    void negationTest() {
+    public void negationTest() {
         String e = "not (\"getArchivedObjects_filter_table\".\"directory\" like 'f17')";
         String eStream = "not (\"streamdb\".\"stream\".\"directory\" like 'f17')";
         Condition elementCondition = new IndexCondition("f17", "NOT_EQUALS", false).condition();
@@ -79,7 +79,7 @@ public class IndexConditionTest {
     }
 
     @Test
-    void equalsTest() {
+    public void equalsTest() {
         IndexCondition eq1 = new IndexCondition("946677600", "EQUALS", false);
         eq1.condition();
         IndexCondition eq2 = new IndexCondition("946677600", "EQUALS", false);
@@ -91,7 +91,7 @@ public class IndexConditionTest {
     }
 
     @Test
-    void notEqualsTest() {
+    public void notEqualsTest() {
         IndexCondition eq1 = new IndexCondition("946677600", "EQUALS", false);
         IndexCondition notEq = new IndexCondition("1000", "EQUALS", false);
         IndexCondition notEq2 = new IndexCondition("946677600", "EQUALS", true);
@@ -101,7 +101,7 @@ public class IndexConditionTest {
     }
 
     @Test
-    void hashCodeTest() {
+    public void hashCodeTest() {
         IndexCondition eq1 = new IndexCondition("946677600", "EQUALS", false);
         IndexCondition eq2 = new IndexCondition("946677600", "EQUALS", false);
         IndexCondition eq3 = new IndexCondition("946677600", "EQUALS", true);

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexConditionTest.java
@@ -45,6 +45,8 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
+import com.teragrep.pth_06.planner.CategoryTableImpl;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -108,5 +110,14 @@ public class IndexConditionTest {
         Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
         Assertions.assertEquals(eq3.hashCode(), eq4.hashCode());
         Assertions.assertNotEquals(eq1.hashCode(), eq4.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(IndexCondition.class)
+                .withNonnullFields("value")
+                .withNonnullFields("operation")
+                .withNonnullFields("streamQuery")
+                .verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexStatementConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexStatementConditionTest.java
@@ -46,7 +46,6 @@
 package com.teragrep.pth_06.planner.walker.conditions;
 
 import com.teragrep.pth_06.config.ConditionConfig;
-import com.teragrep.pth_06.planner.CategoryTableImpl;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.spark.util.sketch.BloomFilter;
 import org.jooq.Condition;
@@ -250,7 +249,8 @@ public class IndexStatementConditionTest {
 
     @Test
     public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(IndexStatementCondition.class)
+        EqualsVerifier
+                .forClass(IndexStatementCondition.class)
                 .withNonnullFields("value")
                 .withNonnullFields("config")
                 .withNonnullFields("condition")

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexStatementConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexStatementConditionTest.java
@@ -46,6 +46,8 @@
 package com.teragrep.pth_06.planner.walker.conditions;
 
 import com.teragrep.pth_06.config.ConditionConfig;
+import com.teragrep.pth_06.planner.CategoryTableImpl;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.spark.util.sketch.BloomFilter;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
@@ -244,6 +246,17 @@ public class IndexStatementConditionTest {
         IndexStatementCondition notEq = new IndexStatementCondition("1000", mockConfig);
         Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
         Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(IndexStatementCondition.class)
+                .withNonnullFields("value")
+                .withNonnullFields("config")
+                .withNonnullFields("condition")
+                .withNonnullFields("tableSet")
+                .withIgnoredFields("LOGGER")
+                .verify();
     }
 
     private void writeFilter(String tableName, int filterId) {

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexStatementConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexStatementConditionTest.java
@@ -89,7 +89,7 @@ public class IndexStatementConditionTest {
     final Connection conn = Assertions.assertDoesNotThrow(() -> DriverManager.getConnection(url, userName, password));
 
     @BeforeAll
-    void setup() {
+    public void setup() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();
             conn.prepareStatement("USE BLOOMDB").execute();
@@ -132,7 +132,7 @@ public class IndexStatementConditionTest {
     }
 
     @AfterAll
-    void tearDown() {
+    public void tearDown() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("DROP ALL OBJECTS"); // h2 clear database
             conn.close();
@@ -140,7 +140,7 @@ public class IndexStatementConditionTest {
     }
 
     @Test
-    void testConnectionException() {
+    public void testConnectionException() {
         DSLContext ctx = DSL.using(new MockConnection(c -> new MockResult[0]));
         ConditionConfig config = new ConditionConfig(ctx, false, true);
         ConditionConfig noBloomConfig = new ConditionConfig(ctx, false);
@@ -151,7 +151,7 @@ public class IndexStatementConditionTest {
     }
 
     @Test
-    void noMatchesTest() {
+    public void noMatchesTest() {
         DSLContext ctx = DSL.using(conn);
         Condition e1 = DSL.falseCondition();
         Condition e2 = DSL.trueCondition();
@@ -166,7 +166,7 @@ public class IndexStatementConditionTest {
     }
 
     @Test
-    void oneMatchingTableTest() {
+    public void oneMatchingTableTest() {
         DSLContext ctx = DSL.using(conn);
         ConditionConfig config = new ConditionConfig(ctx, false, true);
         IndexStatementCondition cond = new IndexStatementCondition("192.168.1.1", config);
@@ -182,7 +182,7 @@ public class IndexStatementConditionTest {
     }
 
     @Test
-    void testOneMatchWithoutFilters() {
+    public void testOneMatchWithoutFilters() {
         DSLContext ctx = DSL.using(conn);
         ConditionConfig config = new ConditionConfig(ctx, false, true, true);
         IndexStatementCondition cond = new IndexStatementCondition("192.168.1.1", config);
@@ -192,7 +192,7 @@ public class IndexStatementConditionTest {
     }
 
     @Test
-    void testTwoMatchWithoutFilters() {
+    public void testTwoMatchWithoutFilters() {
         DSLContext ctx = DSL.using(conn);
         ConditionConfig config = new ConditionConfig(ctx, false, true, true);
         IndexStatementCondition cond = new IndexStatementCondition("255.255.255.255", config);
@@ -203,7 +203,7 @@ public class IndexStatementConditionTest {
     }
 
     @Test
-    void twoMatchingTableTest() {
+    public void twoMatchingTableTest() {
         DSLContext ctx = DSL.using(conn);
         ConditionConfig config = new ConditionConfig(ctx, false, true);
         IndexStatementCondition cond = new IndexStatementCondition("255.255.255.255", config);
@@ -225,21 +225,21 @@ public class IndexStatementConditionTest {
     }
 
     @Test
-    void equalsTest() {
+    public void equalsTest() {
         IndexStatementCondition eq1 = new IndexStatementCondition("946677600", mockConfig);
         IndexStatementCondition eq2 = new IndexStatementCondition("946677600", mockConfig);
         Assertions.assertEquals(eq1, eq2);
     }
 
     @Test
-    void notEqualsTest() {
+    public void notEqualsTest() {
         IndexStatementCondition eq1 = new IndexStatementCondition("946677600", mockConfig);
         IndexStatementCondition notEq = new IndexStatementCondition("1000", mockConfig);
         Assertions.assertNotEquals(eq1, notEq);
     }
 
     @Test
-    void hashCodeTest() {
+    public void hashCodeTest() {
         IndexStatementCondition eq1 = new IndexStatementCondition("946677600", mockConfig);
         IndexStatementCondition eq2 = new IndexStatementCondition("946677600", mockConfig);
         IndexStatementCondition notEq = new IndexStatementCondition("1000", mockConfig);

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexStatementConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexStatementConditionTest.java
@@ -237,6 +237,15 @@ public class IndexStatementConditionTest {
         Assertions.assertNotEquals(eq1, notEq);
     }
 
+    @Test
+    void hashCodeTest() {
+        IndexStatementCondition eq1 = new IndexStatementCondition("946677600", mockConfig);
+        IndexStatementCondition eq2 = new IndexStatementCondition("946677600", mockConfig);
+        IndexStatementCondition notEq = new IndexStatementCondition("1000", mockConfig);
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
+    }
+
     private void writeFilter(String tableName, int filterId) {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
@@ -45,6 +45,8 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
+import com.teragrep.pth_06.planner.CategoryTableImpl;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -101,5 +103,12 @@ class LatestConditionTest {
         LatestCondition notEq = new LatestCondition("1000");
         Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
         Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(LatestCondition.class)
+                .withNonnullFields("value")
+                .verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
@@ -45,7 +45,6 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
-import com.teragrep.pth_06.planner.CategoryTableImpl;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
@@ -107,8 +106,6 @@ class LatestConditionTest {
 
     @Test
     public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(LatestCondition.class)
-                .withNonnullFields("value")
-                .verify();
+        EqualsVerifier.forClass(LatestCondition.class).withNonnullFields("value").verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
@@ -93,4 +93,13 @@ class LatestConditionTest {
         LatestCondition notEq = new LatestCondition("1000");
         Assertions.assertNotEquals(eq1, notEq);
     }
+
+    @Test
+    void hashCodeTest() {
+        LatestCondition eq1 = new LatestCondition("946720800");
+        LatestCondition eq2 = new LatestCondition("946720800");
+        LatestCondition notEq = new LatestCondition("1000");
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
+    }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
@@ -56,10 +56,10 @@ import org.junit.jupiter.api.Test;
  * 
  * @see org.jooq.QueryPart
  */
-class LatestConditionTest {
+public class LatestConditionTest {
 
     @Test
-    void conditionTest() {
+    public void conditionTest() {
         String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" <= date '1970-01-01'\n"
                 + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1000)\n"
                 + ")";
@@ -68,7 +68,7 @@ class LatestConditionTest {
     }
 
     @Test
-    void conditionUpdatedTest() {
+    public void conditionUpdatedTest() {
         String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" <= date '2000-01-01'\n"
                 + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 946720800)\n"
                 + ")";
@@ -77,7 +77,7 @@ class LatestConditionTest {
     }
 
     @Test
-    void equalsTest() {
+    public void equalsTest() {
         LatestCondition eq1 = new LatestCondition("946720800");
         eq1.condition();
         LatestCondition eq2 = new LatestCondition("946720800");
@@ -89,14 +89,14 @@ class LatestConditionTest {
     }
 
     @Test
-    void notEqualsTest() {
+    public void notEqualsTest() {
         LatestCondition eq1 = new LatestCondition("946720800");
         LatestCondition notEq = new LatestCondition("1000");
         Assertions.assertNotEquals(eq1, notEq);
     }
 
     @Test
-    void hashCodeTest() {
+    public void hashCodeTest() {
         LatestCondition eq1 = new LatestCondition("946720800");
         LatestCondition eq2 = new LatestCondition("946720800");
         LatestCondition notEq = new LatestCondition("1000");

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/PatternMatchConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/PatternMatchConditionTest.java
@@ -45,7 +45,6 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
-import com.teragrep.pth_06.planner.CategoryTableImpl;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
@@ -103,8 +102,6 @@ class PatternMatchConditionTest {
 
     @Test
     public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(PatternMatchCondition.class)
-                .withNonnullFields("value")
-                .verify();
+        EqualsVerifier.forClass(PatternMatchCondition.class).withNonnullFields("value").verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/PatternMatchConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/PatternMatchConditionTest.java
@@ -45,6 +45,8 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
+import com.teragrep.pth_06.planner.CategoryTableImpl;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -97,5 +99,12 @@ class PatternMatchConditionTest {
         PatternMatchCondition notEq = new PatternMatchCondition("next");
         Assertions.assertEquals(cond1.hashCode(), cond2.hashCode());
         Assertions.assertNotEquals(cond1.hashCode(), notEq.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(PatternMatchCondition.class)
+                .withNonnullFields("value")
+                .verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/PatternMatchConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/PatternMatchConditionTest.java
@@ -56,17 +56,17 @@ import org.junit.jupiter.api.Test;
  *
  * @see org.jooq.QueryPart
  */
-class PatternMatchConditionTest {
+public class PatternMatchConditionTest {
 
     @Test
-    void testSingleToken() {
+    public void testSingleToken() {
         Condition condition = new PatternMatchCondition("test").condition();
         String e = "('test' like_regex \"bloomdb\".\"filtertype\".\"pattern\")";
         Assertions.assertEquals(e, condition.toString());
     }
 
     @Test
-    void testMultipleTokens() {
+    public void testMultipleTokens() {
         Condition condition = new PatternMatchCondition("test.nest").condition();
         String e = "(\n" + "  ('test.' like_regex \"bloomdb\".\"filtertype\".\"pattern\")\n"
                 + "  or ('.nest' like_regex \"bloomdb\".\"filtertype\".\"pattern\")\n"
@@ -78,21 +78,21 @@ class PatternMatchConditionTest {
     }
 
     @Test
-    void testEquality() {
+    public void testEquality() {
         PatternMatchCondition cond1 = new PatternMatchCondition("test");
         PatternMatchCondition cond2 = new PatternMatchCondition("test");
         Assertions.assertEquals(cond1, cond2);
     }
 
     @Test
-    void testNotEquals() {
+    public void testNotEquals() {
         PatternMatchCondition cond1 = new PatternMatchCondition("test");
         PatternMatchCondition cond2 = new PatternMatchCondition("next");
         Assertions.assertNotEquals(cond1, cond2);
     }
 
     @Test
-    void testHashCode() {
+    public void testHashCode() {
         PatternMatchCondition cond1 = new PatternMatchCondition("test");
         PatternMatchCondition cond2 = new PatternMatchCondition("test");
         PatternMatchCondition notEq = new PatternMatchCondition("next");

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/PatternMatchConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/PatternMatchConditionTest.java
@@ -89,4 +89,13 @@ class PatternMatchConditionTest {
         PatternMatchCondition cond2 = new PatternMatchCondition("next");
         Assertions.assertNotEquals(cond1, cond2);
     }
+
+    @Test
+    void testHashCode() {
+        PatternMatchCondition cond1 = new PatternMatchCondition("test");
+        PatternMatchCondition cond2 = new PatternMatchCondition("test");
+        PatternMatchCondition notEq = new PatternMatchCondition("next");
+        Assertions.assertEquals(cond1.hashCode(), cond2.hashCode());
+        Assertions.assertNotEquals(cond1.hashCode(), notEq.hashCode());
+    }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/SourceTypeConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/SourceTypeConditionTest.java
@@ -98,4 +98,17 @@ class SourceTypeConditionTest {
         Assertions.assertNotEquals(eq1, notEq2);
         Assertions.assertNotEquals(notEq, notEq2);
     }
+
+    @Test
+    void hashCodeTest() {
+        SourceTypeCondition eq1 = new SourceTypeCondition("946677600", "EQUALS", false);
+        SourceTypeCondition eq2 = new SourceTypeCondition("946677600", "EQUALS", false);
+        SourceTypeCondition notEQ1 = new SourceTypeCondition("946677600", "EQUALS", true);
+        SourceTypeCondition notEQ2 = new SourceTypeCondition("1234", "EQUALS", false);
+        SourceTypeCondition notEQ3 = new SourceTypeCondition("946677600", "NOT_EQUALS", false);
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEQ1.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEQ2.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEQ3.hashCode());
+    }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/SourceTypeConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/SourceTypeConditionTest.java
@@ -45,6 +45,8 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
+import com.teragrep.pth_06.planner.CategoryTableImpl;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -110,5 +112,14 @@ class SourceTypeConditionTest {
         Assertions.assertNotEquals(eq1.hashCode(), notEQ1.hashCode());
         Assertions.assertNotEquals(eq1.hashCode(), notEQ2.hashCode());
         Assertions.assertNotEquals(eq1.hashCode(), notEQ3.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(SourceTypeCondition.class)
+                .withNonnullFields("value")
+                .withNonnullFields("operation")
+                .withNonnullFields("streamQuery")
+                .verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/SourceTypeConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/SourceTypeConditionTest.java
@@ -45,7 +45,6 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
-import com.teragrep.pth_06.planner.CategoryTableImpl;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
@@ -116,7 +115,8 @@ class SourceTypeConditionTest {
 
     @Test
     public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(SourceTypeCondition.class)
+        EqualsVerifier
+                .forClass(SourceTypeCondition.class)
                 .withNonnullFields("value")
                 .withNonnullFields("operation")
                 .withNonnullFields("streamQuery")

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/SourceTypeConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/SourceTypeConditionTest.java
@@ -56,10 +56,10 @@ import org.junit.jupiter.api.Test;
  * 
  * @see org.jooq.QueryPart
  */
-class SourceTypeConditionTest {
+public class SourceTypeConditionTest {
 
     @Test
-    void conditionTest() {
+    public void conditionTest() {
         String e = "\"getArchivedObjects_filter_table\".\"stream\" like 'f17'";
         String eStream = "\"streamdb\".\"stream\".\"stream\" like 'f17'";
         Condition elementCondition = new SourceTypeCondition("f17", "EQUALS", false).condition();
@@ -69,7 +69,7 @@ class SourceTypeConditionTest {
     }
 
     @Test
-    void negationTest() {
+    public void negationTest() {
         String e = "not (\"getArchivedObjects_filter_table\".\"stream\" like 'f17')";
         String eStream = "not (\"streamdb\".\"stream\".\"stream\" like 'f17')";
         Condition elementCondition = new SourceTypeCondition("f17", "NOT_EQUALS", false).condition();
@@ -79,7 +79,7 @@ class SourceTypeConditionTest {
     }
 
     @Test
-    void equalsTest() {
+    public void equalsTest() {
         SourceTypeCondition eq1 = new SourceTypeCondition("946677600", "EQUALS", false);
         eq1.condition();
         SourceTypeCondition eq2 = new SourceTypeCondition("946677600", "EQUALS", false);
@@ -91,7 +91,7 @@ class SourceTypeConditionTest {
     }
 
     @Test
-    void notEqualsTest() {
+    public void notEqualsTest() {
         SourceTypeCondition eq1 = new SourceTypeCondition("946677600", "EQUALS", false);
         SourceTypeCondition notEq = new SourceTypeCondition("1000", "EQUALS", false);
         SourceTypeCondition notEq2 = new SourceTypeCondition("1000", "EQUALS", true);
@@ -101,7 +101,7 @@ class SourceTypeConditionTest {
     }
 
     @Test
-    void hashCodeTest() {
+    public void hashCodeTest() {
         SourceTypeCondition eq1 = new SourceTypeCondition("946677600", "EQUALS", false);
         SourceTypeCondition eq2 = new SourceTypeCondition("946677600", "EQUALS", false);
         SourceTypeCondition notEQ1 = new SourceTypeCondition("946677600", "EQUALS", true);

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ValidElementTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ValidElementTest.java
@@ -45,6 +45,8 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
+import com.teragrep.pth_06.planner.CategoryTableImpl;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
@@ -141,5 +143,12 @@ class ValidElementTest {
         ValidElement notEq = new ValidElement(element2);
         Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
         Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(ValidElement.class)
+                .withNonnullFields("element")
+                .verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ValidElementTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ValidElementTest.java
@@ -127,4 +127,19 @@ class ValidElementTest {
         ValidElement eq2 = new ValidElement(element2);
         Assertions.assertNotEquals(eq1, eq2);
     }
+
+    @Test
+    void hashCodeTest() {
+        Element element = document.createElement("test");
+        element.setAttribute("value", "value");
+        element.setAttribute("operation", "operation");
+        Element element2 = document.createElement("test");
+        element2.setAttribute("value", "value");
+        element2.setAttribute("operation", "notOperation");
+        ValidElement eq1 = new ValidElement(element);
+        ValidElement eq2 = new ValidElement(element);
+        ValidElement notEq = new ValidElement(element2);
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
+    }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ValidElementTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ValidElementTest.java
@@ -45,7 +45,6 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
-import com.teragrep.pth_06.planner.CategoryTableImpl;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -147,8 +146,6 @@ class ValidElementTest {
 
     @Test
     public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(ValidElement.class)
-                .withNonnullFields("element")
-                .verify();
+        EqualsVerifier.forClass(ValidElement.class).withNonnullFields("element").verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ValidElementTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ValidElementTest.java
@@ -59,13 +59,13 @@ import javax.xml.parsers.DocumentBuilderFactory;
  * 
  * @see org.jooq.QueryPart
  */
-class ValidElementTest {
+public class ValidElementTest {
 
     final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     final Document document = Assertions.assertDoesNotThrow(() -> factory.newDocumentBuilder().newDocument());
 
     @Test
-    void validTest() {
+    public void validTest() {
         Element element = document.createElement("test");
         element.setAttribute("value", "value");
         element.setAttribute("operation", "operation");
@@ -78,7 +78,7 @@ class ValidElementTest {
     }
 
     @Test
-    void missingValueTest() {
+    public void missingValueTest() {
         Element noValue = document.createElement("test");
         noValue.setAttribute("operation", "operation");
         ValidElement invalid1 = new ValidElement(noValue);
@@ -86,7 +86,7 @@ class ValidElementTest {
     }
 
     @Test
-    void missingOperationTest() {
+    public void missingOperationTest() {
         Element noValue = document.createElement("test");
         noValue.setAttribute("value", "value");
         ValidElement invalid1 = new ValidElement(noValue);
@@ -94,7 +94,7 @@ class ValidElementTest {
     }
 
     @Test
-    void equalityTest() {
+    public void equalityTest() {
         Element element = document.createElement("test");
         element.setAttribute("value", "value");
         element.setAttribute("operation", "operation");
@@ -104,7 +104,7 @@ class ValidElementTest {
     }
 
     @Test
-    void notEqualValueTest() {
+    public void notEqualValueTest() {
         Element element1 = document.createElement("test");
         element1.setAttribute("value", "value");
         element1.setAttribute("operation", "operation");
@@ -117,7 +117,7 @@ class ValidElementTest {
     }
 
     @Test
-    void notEqualOperationTest() {
+    public void notEqualOperationTest() {
         Element element1 = document.createElement("test");
         element1.setAttribute("value", "value");
         element1.setAttribute("operation", "operation");
@@ -130,7 +130,7 @@ class ValidElementTest {
     }
 
     @Test
-    void hashCodeTest() {
+    public void hashCodeTest() {
         Element element = document.createElement("test");
         element.setAttribute("value", "value");
         element.setAttribute("operation", "operation");


### PR DESCRIPTION
Use Objects.hash(values) to generate hash code for objects where equals() method is overwritten.

Objects.hash uses formula `result = 31 * result + elementHashCode` for good hash distribution. 
`31 * result` which is same as `(x << 5) - result)` (bitwise shift) is optimized for JVM on modern hardware.

null safe method, null values return hash value of 0.

note:  fixed missing object parameter value in ConditionConfig equals method and added test for class 