### PR TITLE
use utc to select rolling day in ArchiveQueryProcessor

### DIFF
--- a/src/main/java/com/teragrep/pth_06/planner/ArchiveQueryProcessor.java
+++ b/src/main/java/com/teragrep/pth_06/planner/ArchiveQueryProcessor.java
@@ -98,8 +98,8 @@ public class ArchiveQueryProcessor implements ArchiveQuery {
         try {
             EarliestWalker earliestWalker = new EarliestWalker();
             this.earliestEpoch = earliestWalker.fromString(config.query);
-            // TODO hack to update startDay from query
-            rollingDay = Instant.ofEpochSecond(this.earliestEpoch).atZone(ZoneId.systemDefault()).toLocalDate();
+            // the earliest walker returns UTC time
+            rollingDay = Instant.ofEpochSecond(this.earliestEpoch).atZone(ZoneId.of("UTC")).toLocalDate();
 
         }
         catch (Exception ex) {


### PR DESCRIPTION
Earliest walker epoch time was from UTC but rolling day was selected using system default timezone. This way days are not lost if time zone difference is greater that timestamp difference to date change

not sure about side effects of this change
