### PR TITLE
Add equality tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,12 +215,6 @@
       <version>2.1.0</version>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>nl.jqno.equalsverifier</groupId>
-      <artifactId>equalsverifier</artifactId>
-      <version>3.16.1</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <directory>${project.basedir}/target</directory>

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,12 @@
       <version>2.1.0</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <version>3.16.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <directory>${project.basedir}/target</directory>

--- a/src/main/java/com/teragrep/pth_06/config/ConditionConfig.java
+++ b/src/main/java/com/teragrep/pth_06/config/ConditionConfig.java
@@ -121,11 +121,12 @@ public final class ConditionConfig {
         }
         final ConditionConfig cast = (ConditionConfig) object;
         return this.bloomEnabled == cast.bloomEnabled && this.streamQuery == cast.streamQuery
-                && this.withoutFilters == cast.withoutFilters && this.ctx == cast.ctx;
+                && this.withoutFilters == cast.withoutFilters && this.ctx == cast.ctx
+                && this.bloomTermId == cast.bloomTermId;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(ctx, streamQuery, bloomEnabled, withoutFilters);
+        return Objects.hash(ctx, streamQuery, bloomEnabled, withoutFilters, bloomTermId);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/config/ConditionConfig.java
+++ b/src/main/java/com/teragrep/pth_06/config/ConditionConfig.java
@@ -107,6 +107,7 @@ public final class ConditionConfig {
         return streamQuery;
     }
 
+    //* DSLContext must be same instance to be equal */
     @Override
     public boolean equals(Object object) {
         if (this == object) {

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/IndexStatementCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/IndexStatementCondition.java
@@ -151,11 +151,12 @@ public final class IndexStatementCondition implements QueryCondition, BloomQuery
             return false;
         }
         final IndexStatementCondition cast = (IndexStatementCondition) object;
-        return this.value.equals(cast.value) && this.config.equals(cast.config);
+        return this.value.equals(cast.value) && this.config.equals(cast.config) && this.condition.equals(cast.condition)
+                && this.tableSet.equals(cast.tableSet);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(value, config);
+        return Objects.hash(value, config, condition, tableSet);
     }
 }

--- a/src/test/java/com/teragrep/pth_06/config/ConditionConfigTest.java
+++ b/src/test/java/com/teragrep/pth_06/config/ConditionConfigTest.java
@@ -43,72 +43,53 @@
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
  */
-package com.teragrep.pth_06.planner.bloomfilter;
+package com.teragrep.pth_06.config;
 
-import com.teragrep.blf_01.Token;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.jooq.tools.jdbc.MockConnection;
+import org.jooq.tools.jdbc.MockResult;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-import java.util.stream.Collectors;
+public class ConditionConfigTest {
 
-public class TokenizedValueTest {
+    DSLContext ctx = DSL.using(new MockConnection(c -> new MockResult[0]));
 
     @Test
-    public void testTokenization() {
-        TokenizedValue result = new TokenizedValue("test.nest");
-        Set<String> tokens = result.tokens().stream().map(Token::toString).collect(Collectors.toSet());
-        Assertions.assertTrue(tokens.contains("nest"));
-        Assertions.assertTrue(tokens.contains("test"));
-        Assertions.assertTrue(tokens.contains("."));
-        Assertions.assertTrue(tokens.contains("test.nest"));
-        Assertions.assertTrue(tokens.contains(".nest"));
-        Assertions.assertTrue(tokens.contains("test."));
-        Assertions.assertEquals(6, tokens.size());
+    void testEquality() {
+        ConditionConfig cond1 = new ConditionConfig(ctx, false, false, 1L);
+        ConditionConfig cond2 = new ConditionConfig(ctx, false, false, 1L);
+        Assertions.assertEquals(cond1, cond2);
     }
 
     @Test
-    public void testEquality() {
-        TokenizedValue value1 = new TokenizedValue("test");
-        TokenizedValue value2 = new TokenizedValue("test");
-        Assertions.assertEquals(value1, value2);
-        value1.tokens();
-        Assertions.assertEquals(value2, value1);
-    }
-
-    @Test
-    public void testNotEquals() {
-        TokenizedValue value1 = new TokenizedValue("test");
-        TokenizedValue value2 = new TokenizedValue("nest");
-        Assertions.assertNotEquals(value1, value2);
+    void testNonEquality() {
+        ConditionConfig cond1 = new ConditionConfig(ctx, false, false);
+        ConditionConfig cond2 = new ConditionConfig(ctx, true, false);
+        ConditionConfig cond3 = new ConditionConfig(ctx, false, true);
+        ConditionConfig cond4 = new ConditionConfig(ctx, false, true, 1L);
+        Assertions.assertNotEquals(cond1, cond2);
+        Assertions.assertNotEquals(cond1, cond3);
+        Assertions.assertNotEquals(cond1, cond4);
     }
 
     @Test
     void testHashCode() {
-        TokenizedValue value1 = new TokenizedValue("test");
-        TokenizedValue value2 = new TokenizedValue("test");
-        TokenizedValue notEq = new TokenizedValue("nest");
-        Assertions.assertEquals(value1.hashCode(), value2.hashCode());
-        Assertions.assertNotEquals(value1.hashCode(), notEq.hashCode());
+        ConditionConfig cond1 = new ConditionConfig(ctx, false, false);
+        ConditionConfig cond2 = new ConditionConfig(ctx, false, false);
+        ConditionConfig cond3 = new ConditionConfig(ctx, true, false);
+        ConditionConfig cond4 = new ConditionConfig(ctx, false, true);
+        ConditionConfig cond5 = new ConditionConfig(ctx, false, false, 1L);
+        Assertions.assertEquals(cond1.hashCode(), cond2.hashCode());
+        Assertions.assertNotEquals(cond1.hashCode(), cond3.hashCode());
+        Assertions.assertNotEquals(cond1.hashCode(), cond4.hashCode());
+        Assertions.assertNotEquals(cond1.hashCode(), cond5.hashCode());
     }
 
     @Test
     public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(TokenizedValue.class).withNonnullFields("value").verify();
-    }
-
-    @Test
-    public void testHashCode() {
-        TokenizedValue value1 = new TokenizedValue("test");
-        TokenizedValue value2 = new TokenizedValue("test");
-        TokenizedValue notEq = new TokenizedValue("nest");
-        Assertions.assertEquals(value1.hashCode(), value2.hashCode());
-        Assertions.assertNotEquals(value1.hashCode(), notEq.hashCode());
-    }
-
-    @Test
-    public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(TokenizedValue.class).withNonnullFields("value").verify();
+        EqualsVerifier.forClass(ConditionConfig.class).verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/bloomfilter/CategoryTableImplTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/bloomfilter/CategoryTableImplTest.java
@@ -284,11 +284,7 @@ public class CategoryTableImplTest {
     public void equalsHashCodeContractTest() {
         EqualsVerifier
                 .forClass(CategoryTableImpl.class)
-                .withNonnullFields("ctx")
-                .withNonnullFields("originTable")
-                .withNonnullFields("bloomTermId")
-                .withNonnullFields("tableCondition")
-                .withNonnullFields("tableFilters")
+                .withNonnullFields("ctx", "originTable", "bloomTermId", "tableFilters")
                 .verify();
     }
 

--- a/src/test/java/com/teragrep/pth_06/planner/bloomfilter/ConditionMatchBloomDBTablesTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/bloomfilter/ConditionMatchBloomDBTablesTest.java
@@ -218,22 +218,8 @@ public class ConditionMatchBloomDBTablesTest {
     }
 
     @Test
-    public void hashCodeTest() {
-        DSLContext ctx = DSL.using(conn);
-        PatternMatchTables eq1 = new PatternMatchTables(ctx, "testinput");
-        PatternMatchTables eq2 = new PatternMatchTables(ctx, "testinput");
-        PatternMatchTables notEq = new PatternMatchTables(ctx, "somethingelse");
-        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
-        Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
-    }
-
-    @Test
-    public void equalsHashCodeContractTest() {
-        EqualsVerifier
-                .forClass(PatternMatchTables.class)
-                .withNonnullFields("ctx")
-                .withNonnullFields("patternMatchCondition")
-                .verify();
+    public void equalsVerifierTest() {
+        EqualsVerifier.forClass(ConditionMatchBloomDBTables.class).withNonnullFields("ctx", "condition").verify();
     }
 
     private void writeFilter(String tableName, int filterId) {

--- a/src/test/java/com/teragrep/pth_06/planner/bloomfilter/ConditionMatchBloomDBTablesTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/bloomfilter/ConditionMatchBloomDBTablesTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth_06.planner.bloomfilter;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.spark.util.sketch.BloomFilter;
 import org.jooq.DSLContext;
 import org.jooq.Named;
@@ -76,7 +77,7 @@ public class ConditionMatchBloomDBTablesTest {
     final Connection conn = Assertions.assertDoesNotThrow(() -> DriverManager.getConnection(url, userName, password));
 
     @BeforeAll
-    void setup() {
+    public void setup() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();
             conn.prepareStatement("USE BLOOMDB").execute();
@@ -127,7 +128,7 @@ public class ConditionMatchBloomDBTablesTest {
     }
 
     @AfterAll
-    void tearDown() {
+    public void tearDown() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("DROP ALL OBJECTS").execute(); //h2 clear database
             conn.close();
@@ -214,6 +215,25 @@ public class ConditionMatchBloomDBTablesTest {
         ConditionMatchBloomDBTables eq2 = new ConditionMatchBloomDBTables(ctx2, "testinput");
         Assertions.assertNotEquals(eq1, eq2);
         Assertions.assertNotEquals(eq2, eq1);
+    }
+
+    @Test
+    public void hashCodeTest() {
+        DSLContext ctx = DSL.using(conn);
+        PatternMatchTables eq1 = new PatternMatchTables(ctx, "testinput");
+        PatternMatchTables eq2 = new PatternMatchTables(ctx, "testinput");
+        PatternMatchTables notEq = new PatternMatchTables(ctx, "somethingelse");
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier
+                .forClass(PatternMatchTables.class)
+                .withNonnullFields("ctx")
+                .withNonnullFields("patternMatchCondition")
+                .verify();
     }
 
     private void writeFilter(String tableName, int filterId) {

--- a/src/test/java/com/teragrep/pth_06/planner/bloomfilter/TableFilterTypesFromMetadataResultTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/bloomfilter/TableFilterTypesFromMetadataResultTest.java
@@ -231,9 +231,7 @@ public class TableFilterTypesFromMetadataResultTest {
     public void equalsHashCodeContractTest() {
         EqualsVerifier
                 .forClass(TableFilterTypesFromMetadata.class)
-                .withNonnullFields("ctx")
-                .withNonnullFields("table")
-                .withNonnullFields("bloomTermId")
+                .withNonnullFields("ctx", "table", "expectedField", "fppField", "patternField", "filterTypeIdField")
                 .verify();
     }
 

--- a/src/test/java/com/teragrep/pth_06/planner/bloomfilter/TableFilterTypesFromMetadataResultTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/bloomfilter/TableFilterTypesFromMetadataResultTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth_06.planner.bloomfilter;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.spark.util.sketch.BloomFilter;
 import org.jooq.DSLContext;
 import org.jooq.Record;
@@ -63,7 +64,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class TableFilterTypesFromMetadataResultTest {
+public class TableFilterTypesFromMetadataResultTest {
 
     final String url = "jdbc:h2:mem:test;MODE=MariaDB;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE";
     final String userName = "sa";
@@ -103,7 +104,7 @@ class TableFilterTypesFromMetadataResultTest {
     }
 
     @BeforeEach
-    void createTargetTable() {
+    public void createTargetTable() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();
             conn.prepareStatement("USE BLOOMDB").execute();
@@ -118,7 +119,7 @@ class TableFilterTypesFromMetadataResultTest {
     }
 
     @AfterAll
-    void tearDown() {
+    public void tearDown() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("DROP ALL OBJECTS").execute(); //h2 clear database
             conn.close();
@@ -126,7 +127,7 @@ class TableFilterTypesFromMetadataResultTest {
     }
 
     @Test
-    void testNoFilterTypes() {
+    public void testNoFilterTypes() {
         DSLContext ctx = DSL.using(conn);
         Table<?> table = ctx
                 .meta()
@@ -140,7 +141,7 @@ class TableFilterTypesFromMetadataResultTest {
     }
 
     @Test
-    void testOneFilterType() {
+    public void testOneFilterType() {
         insertSizedFilterIntoTargetTable(1);
         DSLContext ctx = DSL.using(conn);
         Table<?> table = ctx
@@ -157,7 +158,7 @@ class TableFilterTypesFromMetadataResultTest {
     }
 
     @Test
-    void testMultipleFilterTypes() {
+    public void testMultipleFilterTypes() {
         insertSizedFilterIntoTargetTable(1);
         insertSizedFilterIntoTargetTable(2);
         DSLContext ctx = DSL.using(conn);
@@ -210,7 +211,33 @@ class TableFilterTypesFromMetadataResultTest {
         Assertions.assertNotEquals(result1, result2);
     }
 
-    void insertSizedFilterIntoTargetTable(int filterTypeId) {
+    @Test
+    public void testHashCode() {
+        DSLContext ctx = DSL.using(conn);
+        Table<?> table = ctx
+                .meta()
+                .filterSchemas(s -> s.getName().equals("bloomdb"))
+                .filterTables(t -> !t.getName().equals("filtertype"))
+                .getTables()
+                .get(0);
+        TableFilterTypesFromMetadata result1 = new TableFilterTypesFromMetadata(ctx, table, 0L);
+        TableFilterTypesFromMetadata result2 = new TableFilterTypesFromMetadata(ctx, table, 0L);
+        TableFilterTypesFromMetadata notEq = new TableFilterTypesFromMetadata(ctx, table, 1L);
+        Assertions.assertEquals(result1.hashCode(), result2.hashCode());
+        Assertions.assertNotEquals(result1.hashCode(), notEq.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier
+                .forClass(TableFilterTypesFromMetadata.class)
+                .withNonnullFields("ctx")
+                .withNonnullFields("table")
+                .withNonnullFields("bloomTermId")
+                .verify();
+    }
+
+    private void insertSizedFilterIntoTargetTable(int filterTypeId) {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();
             conn.prepareStatement("USE BLOOMDB").execute();

--- a/src/test/java/com/teragrep/pth_06/planner/bloomfilter/TableFiltersTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/bloomfilter/TableFiltersTest.java
@@ -64,7 +64,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class TableFiltersTest {
+public class TableFiltersTest {
 
     final String url = "jdbc:h2:mem:test;MODE=MariaDB;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE";
     final String userName = "sa";
@@ -104,7 +104,7 @@ class TableFiltersTest {
     }
 
     @BeforeEach
-    void createTargetTable() {
+    public void createTargetTable() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();
             conn.prepareStatement("USE BLOOMDB").execute();
@@ -122,7 +122,7 @@ class TableFiltersTest {
     }
 
     @AfterAll
-    void tearDown() {
+    public void tearDown() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("DROP ALL OBJECTS").execute(); //h2 clear database
             conn.close();

--- a/src/test/java/com/teragrep/pth_06/planner/bloomfilter/TokenizedValueTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/bloomfilter/TokenizedValueTest.java
@@ -97,18 +97,4 @@ public class TokenizedValueTest {
     public void equalsHashCodeContractTest() {
         EqualsVerifier.forClass(TokenizedValue.class).withNonnullFields("value").verify();
     }
-
-    @Test
-    public void testHashCode() {
-        TokenizedValue value1 = new TokenizedValue("test");
-        TokenizedValue value2 = new TokenizedValue("test");
-        TokenizedValue notEq = new TokenizedValue("nest");
-        Assertions.assertEquals(value1.hashCode(), value2.hashCode());
-        Assertions.assertNotEquals(value1.hashCode(), notEq.hashCode());
-    }
-
-    @Test
-    public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(TokenizedValue.class).withNonnullFields("value").verify();
-    }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/bloomfilter/TokensAsStringsTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/bloomfilter/TokensAsStringsTest.java
@@ -46,6 +46,7 @@
 package com.teragrep.pth_06.planner.bloomfilter;
 
 import com.teragrep.blf_01.Token;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -64,5 +65,10 @@ public class TokensAsStringsTest {
         Assertions.assertTrue(toStrings.tokens().contains("two"));
         Assertions.assertTrue(toStrings.tokens().contains("three"));
         Assertions.assertEquals(16, toStrings.tokens().size());
+    }
+
+    @Test
+    public void equalsVerifierTest() {
+        EqualsVerifier.forClass(TokensAsStrings.class).withNonnullFields("origin").verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/CategoryTableConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/CategoryTableConditionTest.java
@@ -214,10 +214,12 @@ public class CategoryTableConditionTest {
                 .filterTables(t -> !t.getName().equals("filtertype"))
                 .getTables()
                 .get(0);
+        Table<?> target2 = ctx.meta().filterSchemas(s -> s.getName().equals("bloomdb")).getTables().get(0);
+
         CategoryTableCondition cond1 = new CategoryTableCondition(target1, 0L);
         CategoryTableCondition condEq = new CategoryTableCondition(target1, 0L);
         CategoryTableCondition cond2 = new CategoryTableCondition(target1, 1L);
-        CategoryTableCondition cond3 = new CategoryTableCondition(null, 1L);
+        CategoryTableCondition cond3 = new CategoryTableCondition(target2, 1L);
         Assertions.assertEquals(cond1.hashCode(), condEq.hashCode());
         Assertions.assertNotEquals(cond1.hashCode(), cond2.hashCode());
         Assertions.assertNotEquals(cond1.hashCode(), cond3.hashCode());
@@ -227,8 +229,7 @@ public class CategoryTableConditionTest {
     public void equalsverifier() {
         EqualsVerifier
                 .forClass(CategoryTableCondition.class)
-                .withNonnullFields("bloomTermId")
-                .withNonnullFields("comparedTo")
+                .withNonnullFields("comparedTo", "bloomTermCondition", "typeIdCondition", "categoryTable")
                 .verify();
     }
 

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/CategoryTableConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/CategoryTableConditionTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.spark.util.sketch.BloomFilter;
 import org.jooq.DSLContext;
 import org.jooq.Table;
@@ -66,7 +67,7 @@ import java.util.List;
  * @see org.jooq.QueryPart
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class CategoryTableConditionTest {
+public class CategoryTableConditionTest {
 
     final String url = "jdbc:h2:mem:test;MODE=MariaDB;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE";
     final String userName = "sa";
@@ -106,7 +107,7 @@ class CategoryTableConditionTest {
     }
 
     @BeforeEach
-    void createTargetTable() {
+    public void createTargetTable() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS BLOOMDB").execute();
             conn.prepareStatement("USE BLOOMDB").execute();
@@ -121,7 +122,7 @@ class CategoryTableConditionTest {
     }
 
     @AfterAll
-    void tearDown() {
+    public void tearDown() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("DROP ALL OBJECTS").execute(); //h2 clear database
             conn.close();
@@ -129,7 +130,7 @@ class CategoryTableConditionTest {
     }
 
     @Test
-    void testCondition() {
+    public void testCondition() {
         fillTargetTable();
         DSLContext ctx = DSL.using(conn);
         Table<?> target1 = ctx
@@ -148,7 +149,7 @@ class CategoryTableConditionTest {
     }
 
     @Test
-    void testBloomTermId() {
+    public void testBloomTermId() {
         fillTargetTable();
         DSLContext ctx = DSL.using(conn);
         Table<?> target1 = ctx
@@ -201,6 +202,34 @@ class CategoryTableConditionTest {
         CategoryTableCondition cond1 = new CategoryTableCondition(target1, 0L);
         CategoryTableCondition cond2 = new CategoryTableCondition(target1, 1L);
         Assertions.assertNotEquals(cond1, cond2);
+    }
+
+    @Test
+    public void testHashCode() {
+        fillTargetTable();
+        DSLContext ctx = DSL.using(conn);
+        Table<?> target1 = ctx
+                .meta()
+                .filterSchemas(s -> s.getName().equals("bloomdb"))
+                .filterTables(t -> !t.getName().equals("filtertype"))
+                .getTables()
+                .get(0);
+        CategoryTableCondition cond1 = new CategoryTableCondition(target1, 0L);
+        CategoryTableCondition condEq = new CategoryTableCondition(target1, 0L);
+        CategoryTableCondition cond2 = new CategoryTableCondition(target1, 1L);
+        CategoryTableCondition cond3 = new CategoryTableCondition(null, 1L);
+        Assertions.assertEquals(cond1.hashCode(), condEq.hashCode());
+        Assertions.assertNotEquals(cond1.hashCode(), cond2.hashCode());
+        Assertions.assertNotEquals(cond1.hashCode(), cond3.hashCode());
+    }
+
+    @Test
+    public void equalsverifier() {
+        EqualsVerifier
+                .forClass(CategoryTableCondition.class)
+                .withNonnullFields("bloomTermId")
+                .withNonnullFields("comparedTo")
+                .verify();
     }
 
     void fillTargetTable() {

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,7 @@ import org.junit.jupiter.api.Test;
 public class EarliestConditionTest {
 
     @Test
-    void conditionTest() {
+    public void conditionTest() {
         String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" >= date '1970-01-01'\n"
                 + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 0)\n"
                 + ")";
@@ -67,17 +68,30 @@ public class EarliestConditionTest {
     }
 
     @Test
-    void equalsTest() {
+    public void equalsTest() {
         EarliestCondition eq1 = new EarliestCondition("946677600");
-        eq1.condition();
         EarliestCondition eq2 = new EarliestCondition("946677600");
         Assertions.assertEquals(eq1, eq2);
     }
 
     @Test
-    void notEqualsTest() {
+    public void notEqualsTest() {
         EarliestCondition eq1 = new EarliestCondition("946677600");
         EarliestCondition notEq = new EarliestCondition("1000");
         Assertions.assertNotEquals(eq1, notEq);
+    }
+
+    @Test
+    public void hashCodeTest() {
+        EarliestCondition eq1 = new EarliestCondition("946677600");
+        EarliestCondition eq2 = new EarliestCondition("946677600");
+        EarliestCondition notEq = new EarliestCondition("1000");
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(EarliestCondition.class).withNonnullFields("value").verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ElementConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ElementConditionTest.java
@@ -46,6 +46,7 @@
 package com.teragrep.pth_06.planner.walker.conditions;
 
 import com.teragrep.pth_06.config.ConditionConfig;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
@@ -65,7 +66,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
  * 
  * @see org.jooq.QueryPart
  */
-class ElementConditionTest {
+public class ElementConditionTest {
 
     final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     final Document document = Assertions.assertDoesNotThrow(() -> factory.newDocumentBuilder().newDocument());
@@ -74,7 +75,7 @@ class ElementConditionTest {
     final ConditionConfig streamConfig = new ConditionConfig(mockCtx, true);
 
     @Test
-    void testStreamTags() {
+    public void testStreamTags() {
         String[] streamTags = {
                 "index", "host", "sourcetype"
         };
@@ -91,7 +92,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void testProvidedElementMissingValue() {
+    public void testProvidedElementMissingValue() {
         Element element = document.createElement("test");
         element.setAttribute("operation", "EQUALS");
         ElementCondition elementCondition = new ElementCondition(element, config);
@@ -101,7 +102,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void testProvidedElementMissingOperation() {
+    public void testProvidedElementMissingOperation() {
         Element element = document.createElement("test");
         element.setAttribute("value", "1000");
         ElementCondition elementCondition = new ElementCondition(element, config);
@@ -111,7 +112,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void testIsIndexStatement() {
+    public void testIsIndexStatement() {
         Element element = document.createElement("indexstatement");
         element.setAttribute("value", "searchTerm");
         element.setAttribute("operation", "EQUALS");
@@ -130,7 +131,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void testIndexStatementWithBadConnection() {
+    public void testIndexStatementWithBadConnection() {
         Element element = document.createElement("indexstatement");
         element.setAttribute("value", "searchTerm");
         element.setAttribute("operation", "EQUALS");
@@ -140,7 +141,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void testTimeQualifiers() {
+    public void testTimeQualifiers() {
         String[] tags = {
                 "earliest", "latest", "index_earliest", "index_latest"
         };
@@ -157,7 +158,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void testInvalidStreamTags() {
+    public void testInvalidStreamTags() {
         String[] tags = {
                 "earliest", "latest", "index_earliest", "index_latest", "indexstatement"
         };
@@ -174,7 +175,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void invalidElementNameTest() {
+    public void invalidElementNameTest() {
         Element element = document.createElement("test");
         element.setAttribute("value", "1000");
         element.setAttribute("operation", "EQUALS");
@@ -188,7 +189,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void equalsTest() {
+    public void equalsTest() {
         Element element = document.createElement("index");
         element.setAttribute("value", "f17");
         element.setAttribute("operation", "EQUALS");
@@ -199,7 +200,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void notEqualsTest() {
+    public void notEqualsTest() {
         Element element = document.createElement("index");
         element.setAttribute("value", "f17");
         element.setAttribute("operation", "EQUALS");
@@ -215,7 +216,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void notEqualsDifferentConfigTest() {
+    public void notEqualsDifferentConfigTest() {
         Element element = document.createElement("index");
         element.setAttribute("value", "f17");
         element.setAttribute("operation", "EQUALS");
@@ -229,7 +230,7 @@ class ElementConditionTest {
     }
 
     @Test
-    void notEqualsDifferentConnectionTest() {
+    public void notEqualsDifferentConnectionTest() {
         Element element = document.createElement("index");
         element.setAttribute("value", "f17");
         element.setAttribute("operation", "EQUALS");
@@ -242,5 +243,29 @@ class ElementConditionTest {
         ElementCondition eq = new ElementCondition(element, cfg1);
         ElementCondition notEq = new ElementCondition(element, cfg2);
         Assertions.assertNotEquals(eq, notEq);
+    }
+
+    @Test
+    public void testHashCode() {
+        Element element = document.createElement("index");
+        element.setAttribute("value", "f17");
+        element.setAttribute("operation", "EQUALS");
+        Element element2 = document.createElement("source");
+        element.setAttribute("value", "f17");
+        element.setAttribute("operation", "EQUALS");
+        ElementCondition eq1 = new ElementCondition(element, config);
+        ElementCondition eq2 = new ElementCondition(element, config);
+        ElementCondition notEq = new ElementCondition(element2, config);
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier
+                .forClass(ElementCondition.class)
+                .withNonnullFields("element")
+                .withNonnullFields("config")
+                .verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ElementConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ElementConditionTest.java
@@ -262,10 +262,22 @@ public class ElementConditionTest {
 
     @Test
     public void equalsHashCodeContractTest() {
+        Element element = document.createElement("index");
+        element.setAttribute("value", "f17");
+        element.setAttribute("operation", "EQUALS");
+        Element element2 = document.createElement("source");
+        element2.setAttribute("value", "f11");
+        element2.setAttribute("operation", "EQUALS");
+
+        // Equalsverifier can't use abstract equals from Element, have to create prefab values
+        ValidElement validElement = new ValidElement(element);
+        ValidElement validElement2 = new ValidElement(element2);
+
         EqualsVerifier
                 .forClass(ElementCondition.class)
                 .withNonnullFields("element")
                 .withNonnullFields("config")
+                .withPrefabValues(ValidElement.class, validElement, validElement2)
                 .verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/HostConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/HostConditionTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,7 @@ import org.junit.jupiter.api.Test;
 public class HostConditionTest {
 
     @Test
-    void conditionTest() {
+    public void conditionTest() {
         HostCondition elementCondition = new HostCondition("f17", "EQUALS", false);
         HostCondition streamElementCondition = new HostCondition("f17", "EQUALS", true);
         String e = "\"getArchivedObjects_filter_table\".\"host\" like 'f17'";
@@ -70,7 +71,7 @@ public class HostConditionTest {
     }
 
     @Test
-    void negationTest() {
+    public void negationTest() {
         HostCondition elementCondition = new HostCondition("f17", "NOT_EQUALS", false);
         HostCondition streamElementCondition = new HostCondition("f17", "NOT_EQUALS", true);
         String e = "not (\"getArchivedObjects_filter_table\".\"host\" like 'f17')";
@@ -82,7 +83,7 @@ public class HostConditionTest {
     }
 
     @Test
-    void equalsTest() {
+    public void equalsTest() {
         HostCondition eq1 = new HostCondition("946677600", "EQUALS", false);
         eq1.condition();
         HostCondition eq2 = new HostCondition("946677600", "EQUALS", false);
@@ -94,12 +95,35 @@ public class HostConditionTest {
     }
 
     @Test
-    void notEqualsTest() {
+    public void notEqualsTest() {
         HostCondition eq1 = new HostCondition("946677600", "EQUALS", false);
         HostCondition notEq = new HostCondition("1000", "EQUALS", false);
         HostCondition notEq2 = new HostCondition("946677600", "EQUALS", true);
         Assertions.assertNotEquals(eq1, notEq);
         Assertions.assertNotEquals(eq1, notEq2);
         Assertions.assertNotEquals(notEq, notEq2);
+    }
+
+    @Test
+    public void hashCodeTest() {
+        HostCondition eq1 = new HostCondition("946677600", "EQUALS", false);
+        HostCondition eq2 = new HostCondition("946677600", "EQUALS", false);
+        HostCondition eq3 = new HostCondition("946677600", "EQUALS", true);
+        HostCondition eq4 = new HostCondition("946677600", "EQUALS", true);
+        HostCondition eq5 = new HostCondition("12344", "EQUALS", false);
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertEquals(eq3.hashCode(), eq4.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), eq4.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), eq5.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier
+                .forClass(HostCondition.class)
+                .withNonnullFields("value")
+                .withNonnullFields("operation")
+                .withNonnullFields("streamQuery")
+                .verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/IndexConditionTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,7 @@ import org.junit.jupiter.api.Test;
 public class IndexConditionTest {
 
     @Test
-    void conditionTest() {
+    public void conditionTest() {
         String e = "\"getArchivedObjects_filter_table\".\"directory\" like 'f17'";
         String eStream = "\"streamdb\".\"stream\".\"directory\" like 'f17'";
         Condition elementCondition = new IndexCondition("f17", "EQUALS", false).condition();
@@ -68,7 +69,7 @@ public class IndexConditionTest {
     }
 
     @Test
-    void negationTest() {
+    public void negationTest() {
         String e = "not (\"getArchivedObjects_filter_table\".\"directory\" like 'f17')";
         String eStream = "not (\"streamdb\".\"stream\".\"directory\" like 'f17')";
         Condition elementCondition = new IndexCondition("f17", "NOT_EQUALS", false).condition();
@@ -78,7 +79,7 @@ public class IndexConditionTest {
     }
 
     @Test
-    void equalsTest() {
+    public void equalsTest() {
         IndexCondition eq1 = new IndexCondition("946677600", "EQUALS", false);
         eq1.condition();
         IndexCondition eq2 = new IndexCondition("946677600", "EQUALS", false);
@@ -90,12 +91,33 @@ public class IndexConditionTest {
     }
 
     @Test
-    void notEqualsTest() {
+    public void notEqualsTest() {
         IndexCondition eq1 = new IndexCondition("946677600", "EQUALS", false);
         IndexCondition notEq = new IndexCondition("1000", "EQUALS", false);
         IndexCondition notEq2 = new IndexCondition("946677600", "EQUALS", true);
         Assertions.assertNotEquals(eq1, notEq);
         Assertions.assertNotEquals(eq1, notEq2);
         Assertions.assertNotEquals(notEq, notEq2);
+    }
+
+    @Test
+    public void hashCodeTest() {
+        IndexCondition eq1 = new IndexCondition("946677600", "EQUALS", false);
+        IndexCondition eq2 = new IndexCondition("946677600", "EQUALS", false);
+        IndexCondition eq3 = new IndexCondition("946677600", "EQUALS", true);
+        IndexCondition eq4 = new IndexCondition("946677600", "EQUALS", true);
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertEquals(eq3.hashCode(), eq4.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), eq4.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier
+                .forClass(IndexCondition.class)
+                .withNonnullFields("value")
+                .withNonnullFields("operation")
+                .withNonnullFields("streamQuery")
+                .verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -55,10 +56,10 @@ import org.junit.jupiter.api.Test;
  * 
  * @see org.jooq.QueryPart
  */
-class LatestConditionTest {
+public class LatestConditionTest {
 
     @Test
-    void conditionTest() {
+    public void conditionTest() {
         String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" <= date '1970-01-01'\n"
                 + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1000)\n"
                 + ")";
@@ -67,7 +68,7 @@ class LatestConditionTest {
     }
 
     @Test
-    void conditionUpdatedTest() {
+    public void conditionUpdatedTest() {
         String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" <= date '2000-01-01'\n"
                 + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 946720800)\n"
                 + ")";
@@ -76,7 +77,7 @@ class LatestConditionTest {
     }
 
     @Test
-    void equalsTest() {
+    public void equalsTest() {
         LatestCondition eq1 = new LatestCondition("946720800");
         eq1.condition();
         LatestCondition eq2 = new LatestCondition("946720800");
@@ -88,9 +89,23 @@ class LatestConditionTest {
     }
 
     @Test
-    void notEqualsTest() {
+    public void notEqualsTest() {
         LatestCondition eq1 = new LatestCondition("946720800");
         LatestCondition notEq = new LatestCondition("1000");
         Assertions.assertNotEquals(eq1, notEq);
+    }
+
+    @Test
+    public void hashCodeTest() {
+        LatestCondition eq1 = new LatestCondition("946720800");
+        LatestCondition eq2 = new LatestCondition("946720800");
+        LatestCondition notEq = new LatestCondition("1000");
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(LatestCondition.class).withNonnullFields("value").verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/SourceTypeConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/SourceTypeConditionTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -55,10 +56,10 @@ import org.junit.jupiter.api.Test;
  * 
  * @see org.jooq.QueryPart
  */
-class SourceTypeConditionTest {
+public class SourceTypeConditionTest {
 
     @Test
-    void conditionTest() {
+    public void conditionTest() {
         String e = "\"getArchivedObjects_filter_table\".\"stream\" like 'f17'";
         String eStream = "\"streamdb\".\"stream\".\"stream\" like 'f17'";
         Condition elementCondition = new SourceTypeCondition("f17", "EQUALS", false).condition();
@@ -68,7 +69,7 @@ class SourceTypeConditionTest {
     }
 
     @Test
-    void negationTest() {
+    public void negationTest() {
         String e = "not (\"getArchivedObjects_filter_table\".\"stream\" like 'f17')";
         String eStream = "not (\"streamdb\".\"stream\".\"stream\" like 'f17')";
         Condition elementCondition = new SourceTypeCondition("f17", "NOT_EQUALS", false).condition();
@@ -78,7 +79,7 @@ class SourceTypeConditionTest {
     }
 
     @Test
-    void equalsTest() {
+    public void equalsTest() {
         SourceTypeCondition eq1 = new SourceTypeCondition("946677600", "EQUALS", false);
         eq1.condition();
         SourceTypeCondition eq2 = new SourceTypeCondition("946677600", "EQUALS", false);
@@ -90,12 +91,35 @@ class SourceTypeConditionTest {
     }
 
     @Test
-    void notEqualsTest() {
+    public void notEqualsTest() {
         SourceTypeCondition eq1 = new SourceTypeCondition("946677600", "EQUALS", false);
         SourceTypeCondition notEq = new SourceTypeCondition("1000", "EQUALS", false);
         SourceTypeCondition notEq2 = new SourceTypeCondition("1000", "EQUALS", true);
         Assertions.assertNotEquals(eq1, notEq);
         Assertions.assertNotEquals(eq1, notEq2);
         Assertions.assertNotEquals(notEq, notEq2);
+    }
+
+    @Test
+    public void hashCodeTest() {
+        SourceTypeCondition eq1 = new SourceTypeCondition("946677600", "EQUALS", false);
+        SourceTypeCondition eq2 = new SourceTypeCondition("946677600", "EQUALS", false);
+        SourceTypeCondition notEQ1 = new SourceTypeCondition("946677600", "EQUALS", true);
+        SourceTypeCondition notEQ2 = new SourceTypeCondition("1234", "EQUALS", false);
+        SourceTypeCondition notEQ3 = new SourceTypeCondition("946677600", "NOT_EQUALS", false);
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEQ1.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEQ2.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEQ3.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier
+                .forClass(SourceTypeCondition.class)
+                .withNonnullFields("value")
+                .withNonnullFields("operation")
+                .withNonnullFields("streamQuery")
+                .verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ValidElementTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ValidElementTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth_06.planner.walker.conditions;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
@@ -58,13 +59,13 @@ import javax.xml.parsers.DocumentBuilderFactory;
  * 
  * @see org.jooq.QueryPart
  */
-class ValidElementTest {
+public class ValidElementTest {
 
     final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     final Document document = Assertions.assertDoesNotThrow(() -> factory.newDocumentBuilder().newDocument());
 
     @Test
-    void validTest() {
+    public void validTest() {
         Element element = document.createElement("test");
         element.setAttribute("value", "value");
         element.setAttribute("operation", "operation");
@@ -77,7 +78,7 @@ class ValidElementTest {
     }
 
     @Test
-    void missingValueTest() {
+    public void missingValueTest() {
         Element noValue = document.createElement("test");
         noValue.setAttribute("operation", "operation");
         ValidElement invalid1 = new ValidElement(noValue);
@@ -85,7 +86,7 @@ class ValidElementTest {
     }
 
     @Test
-    void missingOperationTest() {
+    public void missingOperationTest() {
         Element noValue = document.createElement("test");
         noValue.setAttribute("value", "value");
         ValidElement invalid1 = new ValidElement(noValue);
@@ -93,7 +94,7 @@ class ValidElementTest {
     }
 
     @Test
-    void equalityTest() {
+    public void equalityTest() {
         Element element = document.createElement("test");
         element.setAttribute("value", "value");
         element.setAttribute("operation", "operation");
@@ -103,7 +104,7 @@ class ValidElementTest {
     }
 
     @Test
-    void notEqualValueTest() {
+    public void notEqualValueTest() {
         Element element1 = document.createElement("test");
         element1.setAttribute("value", "value");
         element1.setAttribute("operation", "operation");
@@ -116,7 +117,7 @@ class ValidElementTest {
     }
 
     @Test
-    void notEqualOperationTest() {
+    public void notEqualOperationTest() {
         Element element1 = document.createElement("test");
         element1.setAttribute("value", "value");
         element1.setAttribute("operation", "operation");
@@ -126,5 +127,25 @@ class ValidElementTest {
         ValidElement eq1 = new ValidElement(element1);
         ValidElement eq2 = new ValidElement(element2);
         Assertions.assertNotEquals(eq1, eq2);
+    }
+
+    @Test
+    public void hashCodeTest() {
+        Element element = document.createElement("test");
+        element.setAttribute("value", "value");
+        element.setAttribute("operation", "operation");
+        Element element2 = document.createElement("test");
+        element2.setAttribute("value", "value");
+        element2.setAttribute("operation", "notOperation");
+        ValidElement eq1 = new ValidElement(element);
+        ValidElement eq2 = new ValidElement(element);
+        ValidElement notEq = new ValidElement(element2);
+        Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
+        Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContractTest() {
+        EqualsVerifier.forClass(ValidElement.class).withNonnullFields("element").verify();
     }
 }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ValidElementTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ValidElementTest.java
@@ -146,6 +146,18 @@ public class ValidElementTest {
 
     @Test
     public void equalsHashCodeContractTest() {
-        EqualsVerifier.forClass(ValidElement.class).withNonnullFields("element").verify();
+        // Element is abstract, have to give prefab values to EqualsVerifier
+        Element element = document.createElement("test");
+        element.setAttribute("value", "value");
+        element.setAttribute("operation", "operation");
+        Element element2 = document.createElement("test");
+        element2.setAttribute("value", "value");
+        element2.setAttribute("operation", "notOperation");
+
+        EqualsVerifier
+                .forClass(ValidElement.class)
+                .withNonnullFields("element")
+                .withPrefabValues(Element.class, element, element2)
+                .verify();
     }
 }


### PR DESCRIPTION
Adds equality tests originally developed to PR #100 . Equals and hashcode methods were overridden in a previous merged PR so the code for the equals and hashcode methods weren't needed anymore from #100.

There were issues in a few objects that were caught by equalsVerifier, fixed those.