### PR TITLE
Bumped kafka-clients version to 3.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>2.1.0</version>
+      <version>3.9.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Includes kafka-clients version update from 2.1.0 to 3.9.0.

Resolves issue #188 