### PR TITLE
Refactor planner Kafka Query

### DIFF
--- a/src/main/java/com/teragrep/pth_06/ArchiveMicroStreamReader.java
+++ b/src/main/java/com/teragrep/pth_06/ArchiveMicroStreamReader.java
@@ -106,7 +106,7 @@ public final class ArchiveMicroStreamReader implements MicroBatchStream {
         }
 
         if (config.isKafkaEnabled) {
-            this.kq = new KafkaQueryProcessor(config);
+            this.kq = new KafkaQueryImpl(config);
         }
         else {
             this.kq = null;

--- a/src/main/java/com/teragrep/pth_06/planner/KafkaQueryImpl.java
+++ b/src/main/java/com/teragrep/pth_06/planner/KafkaQueryImpl.java
@@ -1,3 +1,48 @@
+/*
+ * Teragrep Archive Datasource (pth_06)
+ * Copyright (C) 2021-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
 package com.teragrep.pth_06.planner;
 
 import com.teragrep.pth_06.config.Config;
@@ -19,19 +64,30 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-public class KafkaQueryImpl implements KafkaQuery {
+public final class KafkaQueryImpl implements KafkaQuery {
+
     private final Logger LOGGER = LoggerFactory.getLogger(KafkaQueryImpl.class);
 
     private final KafkaSubscriptionPatternFromQuery patternFromQuery;
     private final Consumer<byte[], byte[]> consumer;
-    private final Map<TopicPartition, Long> persistedEndOffsetMap;
+    private final Map<TopicPartition, Long> persistedEndOffsetMap; // used as a cache when not processing continuously
     private final boolean isContinuouslyProcessing;
 
     public KafkaQueryImpl(final Config config) {
-        this(new KafkaSubscriptionPatternFromQuery(config.query), new KafkaConsumer<>(config.kafkaConfig.driverOpts), new HashMap<>(), config.kafkaConfig.kafkaContinuousProcessing);
+        this(
+                new KafkaSubscriptionPatternFromQuery(config.query),
+                new KafkaConsumer<>(config.kafkaConfig.driverOpts),
+                new HashMap<>(),
+                config.kafkaConfig.kafkaContinuousProcessing
+        );
     }
 
-    public KafkaQueryImpl(final KafkaSubscriptionPatternFromQuery patternFromQuery, final Consumer<byte[], byte[]> consumer, final Map<TopicPartition, Long> persistedEndOffsetMap, final boolean isContinuouslyProcessing) {
+    public KafkaQueryImpl(
+            final KafkaSubscriptionPatternFromQuery patternFromQuery,
+            final Consumer<byte[], byte[]> consumer,
+            final Map<TopicPartition, Long> persistedEndOffsetMap,
+            final boolean isContinuouslyProcessing
+    ) {
         this.patternFromQuery = patternFromQuery;
         this.consumer = consumer;
         this.persistedEndOffsetMap = persistedEndOffsetMap;
@@ -40,27 +96,35 @@ public class KafkaQueryImpl implements KafkaQuery {
 
     public Set<TopicPartition> authorizedMatchingTopicPartitions() {
         final Pattern pattern = patternFromQuery.pattern();
-        final Set<String> matchingTopics = consumer.listTopics().keySet().stream()
+        LOGGER.info("Filtering topics using pattern <{}>", pattern.pattern());
+        final Set<String> matchingTopics = consumer
+                .listTopics()
+                .keySet()
+                .stream()
                 .filter(topic -> pattern.matcher(topic).matches())
                 .collect(Collectors.toSet());
 
         final Set<TopicPartition> authorizedTopicPartitions = new HashSet<>();
 
         // filter out topics that do not match regex or that have no authorization
-        for (final String topic: matchingTopics) {
+        for (final String topic : matchingTopics) {
             try {
-                final List<PartitionInfo> partitions = consumer.partitionsFor(topic); // can throw TopicAuthorizationException
-                authorizedTopicPartitions.addAll(partitions.stream()
-                        .map(partitionInfo -> new TopicPartition(topic, partitionInfo.partition())).collect(Collectors.toSet()
-                        )
-                );
-            } catch (final TopicAuthorizationException e) {
+                final List<PartitionInfo> partitions = consumer.partitionsFor(topic); // can throw TopicAuthorizationException same as poll()
+                authorizedTopicPartitions
+                        .addAll(
+                                partitions
+                                        .stream()
+                                        .map(partitionInfo -> new TopicPartition(topic, partitionInfo.partition()))
+                                        .collect(Collectors.toSet())
+                        );
+            }
+            catch (final TopicAuthorizationException e) {
                 LOGGER.info("Skipping unauthorized topic <{}>", topic);
             }
         }
 
         if (authorizedTopicPartitions.isEmpty()) {
-            LOGGER.warn("Found no authorized topics for given pattern <{}>", pattern);
+            LOGGER.warn("Found no authorized topics for given pattern <{}>, no kafka data will be available", pattern);
         }
 
         return authorizedTopicPartitions;

--- a/src/main/java/com/teragrep/pth_06/planner/KafkaQueryImpl.java
+++ b/src/main/java/com/teragrep/pth_06/planner/KafkaQueryImpl.java
@@ -1,0 +1,180 @@
+package com.teragrep.pth_06.planner;
+
+import com.teragrep.pth_06.config.Config;
+import com.teragrep.pth_06.planner.offset.KafkaOffset;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class KafkaQueryImpl implements KafkaQuery {
+    private final Logger LOGGER = LoggerFactory.getLogger(KafkaQueryImpl.class);
+
+    private final String query;
+    private final Consumer<byte[], byte[]> consumer;
+    private final Map<TopicPartition, Long> persistedEndOffsetMap;
+    private final boolean isContinuouslyProcessing;
+
+    public KafkaQueryImpl(final Config config) {
+        this(config.query, new KafkaConsumer<>(config.kafkaConfig.driverOpts), new HashMap<>(), config.kafkaConfig.kafkaContinuousProcessing);
+    }
+
+    public KafkaQueryImpl(final String query, final Consumer<byte[], byte[]> consumer, final Map<TopicPartition, Long> persistedEndOffsetMap, final boolean isContinuouslyProcessing) {
+        this.query = query;
+        this.consumer = consumer;
+        this.persistedEndOffsetMap = persistedEndOffsetMap;
+        this.isContinuouslyProcessing = isContinuouslyProcessing;
+    }
+
+    @Override
+    public Map<TopicPartition, Long> getInitialEndOffsets() {
+        return getEndOffsets(null);
+    }
+
+    @Override
+    public Map<TopicPartition, Long> getEndOffsets(final KafkaOffset startOffset) {
+        final Set<TopicPartition> topicPartitionSet = topicPartitionSet();
+
+        if (persistedEndOffsetMap.isEmpty() || isContinuouslyProcessing) {
+            final Map<TopicPartition, Long> topicPartitionEndOffsetMap = new HashMap<>();
+            final Map<TopicPartition, Long> endOffsets = consumer.endOffsets(topicPartitionSet, Duration.ofSeconds(60)); // TODO parametrize
+
+            for (final TopicPartition topicPartition : topicPartitionSet) {
+                final long partitionEnd = endOffsets.get(topicPartition); // partition end becomes the current end
+
+                topicPartitionEndOffsetMap.put(topicPartition, partitionEnd);
+            }
+            persistedEndOffsetMap.putAll(topicPartitionEndOffsetMap);
+            return topicPartitionEndOffsetMap;
+        } else {
+            return persistedEndOffsetMap;
+        }
+    }
+
+    @Override
+    public Map<TopicPartition, Long> getBeginningOffsets(final KafkaOffset endOffset) {
+        final Set<TopicPartition> topicPartitionSet = topicPartitionSet();
+        final Map<TopicPartition, Long> topicPartitionStartOffsetMap = new HashMap<>();
+
+        final Map<TopicPartition, Long> beginningOffsets = consumer
+                .beginningOffsets(topicPartitionSet, Duration.ofSeconds(60));
+
+        for (final TopicPartition topicPartition : topicPartitionSet) {
+            final long partitionStart = beginningOffsets.get(topicPartition); // partition start becomes the current start
+            topicPartitionStartOffsetMap.put(topicPartition, partitionStart);
+        }
+        return topicPartitionStartOffsetMap;
+    }
+
+    @Override
+    public void commit(KafkaOffset offset) {
+
+    }
+
+    private Set<TopicPartition> topicPartitionSet() {
+        final String regexString = new RegexStringFromQuery(query).regexString();
+        final Pattern topicsRegex = Pattern.compile(regexString);
+
+        Set<TopicPartition> localTopicPartitionSet = Collections.emptySet();
+        final int maxRetries = 5;
+        int retries = 0;
+
+        while (localTopicPartitionSet.isEmpty() && (retries < maxRetries)) {
+            final Map<String, List<PartitionInfo>> listTopics;
+            try {
+                listTopics = consumer.listTopics(Duration.ofSeconds(60));
+            } catch (final TopicAuthorizationException topicAuthorizationException) {
+                handleTopicAuthorizationException(regexString, topicAuthorizationException);
+                continue;
+            }
+
+            boolean hasTopicMatch = false;
+
+            for (final Map.Entry<String, List<PartitionInfo>> entry : listTopics.entrySet()) {
+                final Matcher matcher = topicsRegex.matcher(entry.getKey());
+                if (matcher.matches()) {
+                    hasTopicMatch = true;
+
+                    for (PartitionInfo partitionInfo : entry.getValue()) {
+                        TopicPartition topicPartition = new TopicPartition(entry.getKey(), partitionInfo.partition());
+                        consumer.assign(Collections.singleton(topicPartition));
+                    }
+                }
+            }
+
+            // If no topic matches the pattern, warn and break
+            if (!hasTopicMatch && !listTopics.isEmpty()) {
+                LOGGER.warn("Subscribed to topics that do not exist! Kafka data will not be available.");
+                break;
+            }
+
+            localTopicPartitionSet = consumer.assignment();
+
+            if (localTopicPartitionSet.isEmpty()) {
+                retries++;
+                LOGGER.warn("Kafka consumer assignment returned no topics, retry count <{}>", retries);
+            }
+        }
+        return localTopicPartitionSet;
+    }
+
+    private void handleTopicAuthorizationException(
+            final String topicsRegexString,
+            final TopicAuthorizationException topicAuthorizationException
+    ) {
+        // wildcard queries may match topics with no authorization
+        final Set<String> unauthorizedTopics = topicAuthorizationException.unauthorizedTopics();
+
+        // use negative lookahead to cancel unauthorizedTopics:
+        // by prepending it to authorized topics
+        // i.e (?!^not_a|not_b|not_c$)^(yes_x|(yes_y|yes_z))$
+        final StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("(?!");
+
+        int topicsProcessed = 0;
+        for (final String topic : unauthorizedTopics) {
+            stringBuilder.append("^");
+            stringBuilder.append(topic);
+            stringBuilder.append("$");
+            topicsProcessed++;
+
+            if (topicsProcessed < unauthorizedTopics.size()) {
+                stringBuilder.append("|");
+            }
+        }
+        stringBuilder.append(")");
+
+        stringBuilder.append(topicsRegexString);
+
+        final String negatedTopicRegexString = stringBuilder.toString();
+
+        final Pattern negatedTopicRegexPattern = Pattern.compile(negatedTopicRegexString);
+
+        LOGGER.warn(
+                "Re-subscribing: <[{}]> after TopicAuthorizationException: <{}>",
+                negatedTopicRegexPattern, topicAuthorizationException
+        );
+
+        consumer.subscribe(negatedTopicRegexPattern);
+
+        // it seems that kafka may not report all unauthorized topics in a
+        // one go, therefore recursion is needed
+        try {
+            consumer.listTopics(Duration.ofSeconds(60));
+        } catch (final TopicAuthorizationException authorizationException) {
+            handleTopicAuthorizationException(negatedTopicRegexString, authorizationException);
+        }
+    }
+}

--- a/src/main/java/com/teragrep/pth_06/planner/KafkaQueryImpl.java
+++ b/src/main/java/com/teragrep/pth_06/planner/KafkaQueryImpl.java
@@ -11,67 +11,94 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class KafkaQueryImpl implements KafkaQuery {
     private final Logger LOGGER = LoggerFactory.getLogger(KafkaQueryImpl.class);
 
-    private final String query;
+    private final KafkaSubscriptionPatternFromQuery patternFromQuery;
     private final Consumer<byte[], byte[]> consumer;
     private final Map<TopicPartition, Long> persistedEndOffsetMap;
     private final boolean isContinuouslyProcessing;
 
     public KafkaQueryImpl(final Config config) {
-        this(config.query, new KafkaConsumer<>(config.kafkaConfig.driverOpts), new HashMap<>(), config.kafkaConfig.kafkaContinuousProcessing);
+        this(new KafkaSubscriptionPatternFromQuery(config.query), new KafkaConsumer<>(config.kafkaConfig.driverOpts), new HashMap<>(), config.kafkaConfig.kafkaContinuousProcessing);
     }
 
-    public KafkaQueryImpl(final String query, final Consumer<byte[], byte[]> consumer, final Map<TopicPartition, Long> persistedEndOffsetMap, final boolean isContinuouslyProcessing) {
-        this.query = query;
+    public KafkaQueryImpl(final KafkaSubscriptionPatternFromQuery patternFromQuery, final Consumer<byte[], byte[]> consumer, final Map<TopicPartition, Long> persistedEndOffsetMap, final boolean isContinuouslyProcessing) {
+        this.patternFromQuery = patternFromQuery;
         this.consumer = consumer;
         this.persistedEndOffsetMap = persistedEndOffsetMap;
         this.isContinuouslyProcessing = isContinuouslyProcessing;
     }
 
-    @Override
-    public Map<TopicPartition, Long> getInitialEndOffsets() {
-        return getEndOffsets(null);
+    public Set<TopicPartition> authorizedMatchingTopicPartitions() {
+        final Pattern pattern = patternFromQuery.pattern();
+        final Set<String> matchingTopics = consumer.listTopics().keySet().stream()
+                .filter(topic -> pattern.matcher(topic).matches())
+                .collect(Collectors.toSet());
+
+        final Set<TopicPartition> authorizedTopicPartitions = new HashSet<>();
+
+        // filter out topics that do not match regex or that have no authorization
+        for (final String topic: matchingTopics) {
+            try {
+                final List<PartitionInfo> partitions = consumer.partitionsFor(topic); // can throw TopicAuthorizationException
+                authorizedTopicPartitions.addAll(partitions.stream()
+                        .map(partitionInfo -> new TopicPartition(topic, partitionInfo.partition())).collect(Collectors.toSet()
+                        )
+                );
+            } catch (final TopicAuthorizationException e) {
+                LOGGER.info("Skipping unauthorized topic <{}>", topic);
+            }
+        }
+
+        if (authorizedTopicPartitions.isEmpty()) {
+            LOGGER.warn("Found no authorized topics for given pattern <{}>", pattern);
+        }
+
+        return authorizedTopicPartitions;
     }
 
     @Override
-    public Map<TopicPartition, Long> getEndOffsets(final KafkaOffset startOffset) {
-        final Set<TopicPartition> topicPartitionSet = topicPartitionSet();
-
+    public Map<TopicPartition, Long> getInitialEndOffsets() {
         if (persistedEndOffsetMap.isEmpty() || isContinuouslyProcessing) {
+            final Set<TopicPartition> topicPartitions = authorizedMatchingTopicPartitions();
             final Map<TopicPartition, Long> topicPartitionEndOffsetMap = new HashMap<>();
-            final Map<TopicPartition, Long> endOffsets = consumer.endOffsets(topicPartitionSet, Duration.ofSeconds(60)); // TODO parametrize
+            final Map<TopicPartition, Long> endOffsets = consumer.endOffsets(topicPartitions, Duration.ofSeconds(60));
 
-            for (final TopicPartition topicPartition : topicPartitionSet) {
-                final long partitionEnd = endOffsets.get(topicPartition); // partition end becomes the current end
-
+            for (final TopicPartition topicPartition : topicPartitions) {
+                final long partitionEnd = endOffsets.get(topicPartition);
                 topicPartitionEndOffsetMap.put(topicPartition, partitionEnd);
+
             }
             persistedEndOffsetMap.putAll(topicPartitionEndOffsetMap);
             return topicPartitionEndOffsetMap;
-        } else {
+        }
+        else {
             return persistedEndOffsetMap;
         }
     }
 
     @Override
+    public Map<TopicPartition, Long> getEndOffsets(final KafkaOffset startOffset) {
+        return getInitialEndOffsets();
+    }
+
+    @Override
     public Map<TopicPartition, Long> getBeginningOffsets(final KafkaOffset endOffset) {
-        final Set<TopicPartition> topicPartitionSet = topicPartitionSet();
+        final Set<TopicPartition> topicPartitions = authorizedMatchingTopicPartitions();
         final Map<TopicPartition, Long> topicPartitionStartOffsetMap = new HashMap<>();
-
         final Map<TopicPartition, Long> beginningOffsets = consumer
-                .beginningOffsets(topicPartitionSet, Duration.ofSeconds(60));
+                .beginningOffsets(topicPartitions, Duration.ofSeconds(60));
 
-        for (final TopicPartition topicPartition : topicPartitionSet) {
+        for (final TopicPartition topicPartition : topicPartitions) {
             final long partitionStart = beginningOffsets.get(topicPartition); // partition start becomes the current start
             topicPartitionStartOffsetMap.put(topicPartition, partitionStart);
         }
@@ -80,101 +107,5 @@ public class KafkaQueryImpl implements KafkaQuery {
 
     @Override
     public void commit(KafkaOffset offset) {
-
-    }
-
-    private Set<TopicPartition> topicPartitionSet() {
-        final String regexString = new RegexStringFromQuery(query).regexString();
-        final Pattern topicsRegex = Pattern.compile(regexString);
-
-        Set<TopicPartition> localTopicPartitionSet = Collections.emptySet();
-        final int maxRetries = 5;
-        int retries = 0;
-
-        while (localTopicPartitionSet.isEmpty() && (retries < maxRetries)) {
-            final Map<String, List<PartitionInfo>> listTopics;
-            try {
-                listTopics = consumer.listTopics(Duration.ofSeconds(60));
-            } catch (final TopicAuthorizationException topicAuthorizationException) {
-                handleTopicAuthorizationException(regexString, topicAuthorizationException);
-                continue;
-            }
-
-            boolean hasTopicMatch = false;
-
-            for (final Map.Entry<String, List<PartitionInfo>> entry : listTopics.entrySet()) {
-                final Matcher matcher = topicsRegex.matcher(entry.getKey());
-                if (matcher.matches()) {
-                    hasTopicMatch = true;
-
-                    for (PartitionInfo partitionInfo : entry.getValue()) {
-                        TopicPartition topicPartition = new TopicPartition(entry.getKey(), partitionInfo.partition());
-                        consumer.assign(Collections.singleton(topicPartition));
-                    }
-                }
-            }
-
-            // If no topic matches the pattern, warn and break
-            if (!hasTopicMatch && !listTopics.isEmpty()) {
-                LOGGER.warn("Subscribed to topics that do not exist! Kafka data will not be available.");
-                break;
-            }
-
-            localTopicPartitionSet = consumer.assignment();
-
-            if (localTopicPartitionSet.isEmpty()) {
-                retries++;
-                LOGGER.warn("Kafka consumer assignment returned no topics, retry count <{}>", retries);
-            }
-        }
-        return localTopicPartitionSet;
-    }
-
-    private void handleTopicAuthorizationException(
-            final String topicsRegexString,
-            final TopicAuthorizationException topicAuthorizationException
-    ) {
-        // wildcard queries may match topics with no authorization
-        final Set<String> unauthorizedTopics = topicAuthorizationException.unauthorizedTopics();
-
-        // use negative lookahead to cancel unauthorizedTopics:
-        // by prepending it to authorized topics
-        // i.e (?!^not_a|not_b|not_c$)^(yes_x|(yes_y|yes_z))$
-        final StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append("(?!");
-
-        int topicsProcessed = 0;
-        for (final String topic : unauthorizedTopics) {
-            stringBuilder.append("^");
-            stringBuilder.append(topic);
-            stringBuilder.append("$");
-            topicsProcessed++;
-
-            if (topicsProcessed < unauthorizedTopics.size()) {
-                stringBuilder.append("|");
-            }
-        }
-        stringBuilder.append(")");
-
-        stringBuilder.append(topicsRegexString);
-
-        final String negatedTopicRegexString = stringBuilder.toString();
-
-        final Pattern negatedTopicRegexPattern = Pattern.compile(negatedTopicRegexString);
-
-        LOGGER.warn(
-                "Re-subscribing: <[{}]> after TopicAuthorizationException: <{}>",
-                negatedTopicRegexPattern, topicAuthorizationException
-        );
-
-        consumer.subscribe(negatedTopicRegexPattern);
-
-        // it seems that kafka may not report all unauthorized topics in a
-        // one go, therefore recursion is needed
-        try {
-            consumer.listTopics(Duration.ofSeconds(60));
-        } catch (final TopicAuthorizationException authorizationException) {
-            handleTopicAuthorizationException(negatedTopicRegexString, authorizationException);
-        }
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/KafkaSubscriptionPatternFromQuery.java
+++ b/src/main/java/com/teragrep/pth_06/planner/KafkaSubscriptionPatternFromQuery.java
@@ -5,15 +5,16 @@ import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
+import java.util.regex.Pattern;
 
-public class RegexStringFromQuery {
+public class KafkaSubscriptionPatternFromQuery {
     private final String query;
 
-    public RegexStringFromQuery(final String query) {
+    public KafkaSubscriptionPatternFromQuery(final String query) {
         this.query = query;
     }
 
-    public String regexString() {
+    public Pattern pattern() {
         String topicsRegexString;
             try {
                 KafkaWalker parser = new KafkaWalker();
@@ -21,13 +22,13 @@ public class RegexStringFromQuery {
             }
             catch (ParserConfigurationException | IOException | SAXException ex) {
                 throw new RuntimeException(
-                        "Exception walking query <" + query
-                                + "> exception:" + ex
+                        "Exception building kafka pattern from query <" + query
+                                + "> exception: " + ex
                 );
             }
         if (topicsRegexString == null) {
             topicsRegexString = "^.*$"; // all topics if null
         }
-        return topicsRegexString;
+        return Pattern.compile(topicsRegexString);
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/RegexStringFromQuery.java
+++ b/src/main/java/com/teragrep/pth_06/planner/RegexStringFromQuery.java
@@ -1,0 +1,33 @@
+package com.teragrep.pth_06.planner;
+
+import com.teragrep.pth_06.planner.walker.KafkaWalker;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+
+public class RegexStringFromQuery {
+    private final String query;
+
+    public RegexStringFromQuery(final String query) {
+        this.query = query;
+    }
+
+    public String regexString() {
+        String topicsRegexString;
+            try {
+                KafkaWalker parser = new KafkaWalker();
+                topicsRegexString = parser.fromString(query);
+            }
+            catch (ParserConfigurationException | IOException | SAXException ex) {
+                throw new RuntimeException(
+                        "Exception walking query <" + query
+                                + "> exception:" + ex
+                );
+            }
+        if (topicsRegexString == null) {
+            topicsRegexString = "^.*$"; // all topics if null
+        }
+        return topicsRegexString;
+    }
+}

--- a/src/test/java/com/teragrep/pth_06/planner/KafkaQueryImplTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/KafkaQueryImplTest.java
@@ -1,0 +1,228 @@
+/*
+ * Teragrep Archive Datasource (pth_06)
+ * Copyright (C) 2021-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.pth_06.planner;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class KafkaQueryImplTest {
+
+    private final Set<TopicPartition> authorizedTopics = new HashSet<>();
+    private final Set<TopicPartition> unauthorizedTopics = new HashSet<>();
+
+    @BeforeAll
+    public void setup() {
+        authorizedTopics.add(new TopicPartition("auth-topic-1", 0));
+        authorizedTopics.add(new TopicPartition("auth-topic-2", 0));
+        unauthorizedTopics.add(new TopicPartition("unauth-topic-1", 0));
+        unauthorizedTopics.add(new TopicPartition("unauth-topic-2", 0));
+    }
+
+    @Test
+    public void testMatchAnyTopic() {
+        final Consumer<byte[], byte[]> consumer = mockConsumer();
+        final KafkaQueryImpl kafkaQuery = new KafkaQueryImpl(
+                new KafkaSubscriptionPatternFromQuery("<index value=\"*\" operation=\"EQUALS\"/>"),
+                consumer,
+                new HashMap<>(),
+                false
+        );
+        final Set<TopicPartition> topicPartitions = kafkaQuery.authorizedMatchingTopicPartitions();
+        Assertions.assertEquals(2, topicPartitions.size());
+        final List<String> topicNames = topicPartitions
+                .stream()
+                .map(TopicPartition::topic)
+                .collect(Collectors.toList());
+        Assertions.assertTrue(topicNames.contains("auth-topic-1"));
+        Assertions.assertTrue(topicNames.contains("auth-topic-2"));
+    }
+
+    @Test
+    public void testNullTopicFromWalker() {
+        final Consumer<byte[], byte[]> consumer = mockConsumer();
+        KafkaQueryImpl kafkaQuery = new KafkaQueryImpl(
+                // operation NOT_EQUALS causes KafkaWalker to return a null String, this is replaced to match all regex
+                new KafkaSubscriptionPatternFromQuery("<index value=\"unauth-topic-1\" operation=\"NOT_EQUALS\"/>"),
+                consumer,
+                new HashMap<>(),
+                false
+        );
+        final Set<TopicPartition> topicPartitions = kafkaQuery.authorizedMatchingTopicPartitions();
+        Assertions.assertEquals(2, topicPartitions.size());
+        final List<String> topicNames = topicPartitions
+                .stream()
+                .map(TopicPartition::topic)
+                .collect(Collectors.toList());
+        Assertions.assertTrue(topicNames.contains("auth-topic-1"));
+        Assertions.assertTrue(topicNames.contains("auth-topic-2"));
+    }
+
+    @Test
+    public void testAuthorizedMatchingTopic() {
+        final Consumer<byte[], byte[]> consumer = mockConsumer();
+        final KafkaQueryImpl kafkaQuery = new KafkaQueryImpl(
+                new KafkaSubscriptionPatternFromQuery("<index value=\"auth-topic-1\" operation=\"EQUALS\"/>"),
+                consumer,
+                new HashMap<>(),
+                false
+        );
+        final Set<TopicPartition> topicPartitions = kafkaQuery.authorizedMatchingTopicPartitions();
+        Assertions.assertEquals(1, topicPartitions.size());
+        Assertions.assertEquals("auth-topic-1", topicPartitions.stream().findFirst().get().topic());
+    }
+
+    @Test
+    public void testAuthorizedMatchingTopicWildcard() {
+        final Consumer<byte[], byte[]> consumer = mockConsumer();
+        final KafkaQueryImpl kafkaQuery = new KafkaQueryImpl(
+                new KafkaSubscriptionPatternFromQuery("<index value=\"auth-topic-*\" operation=\"EQUALS\"/>"),
+                consumer,
+                new HashMap<>(),
+                false
+        );
+        final Set<TopicPartition> topicPartitions = kafkaQuery.authorizedMatchingTopicPartitions();
+        Assertions.assertEquals(2, topicPartitions.size());
+        final List<String> topicNames = topicPartitions
+                .stream()
+                .map(TopicPartition::topic)
+                .collect(Collectors.toList());
+        Assertions.assertTrue(topicNames.contains("auth-topic-1"));
+        Assertions.assertTrue(topicNames.contains("auth-topic-2"));
+    }
+
+    @Test
+    public void testAuthorizedMatchingTopicDoesNotGetUnauthorized() {
+        final Consumer<byte[], byte[]> consumer = mockConsumer();
+        final KafkaQueryImpl kafkaQuery = new KafkaQueryImpl(
+                new KafkaSubscriptionPatternFromQuery("<index value=\"unauth-topic-1\" operation=\"EQUALS\"/>"),
+                consumer,
+                new HashMap<>(),
+                false
+        );
+        final Set<TopicPartition> topicPartitions = kafkaQuery.authorizedMatchingTopicPartitions();
+        Assertions.assertEquals(0, topicPartitions.size());
+    }
+
+    @Test
+    public void testAuthorizedMatchingTopicDoesNotGetUnauthorizedWildcard() {
+        final Consumer<byte[], byte[]> consumer = mockConsumer();
+        final KafkaQueryImpl kafkaQuery = new KafkaQueryImpl(
+                new KafkaSubscriptionPatternFromQuery("<index value=\"unauth-topic-*\" operation=\"EQUALS\"/>"),
+                consumer,
+                new HashMap<>(),
+                false
+        );
+        final Set<TopicPartition> topicPartitions = kafkaQuery.authorizedMatchingTopicPartitions();
+        Assertions.assertEquals(0, topicPartitions.size());
+    }
+
+    private Consumer<byte[], byte[]> mockConsumer() {
+        final Consumer<byte[], byte[]> consumerMock = mock(KafkaConsumer.class);
+        final Map<String, List<PartitionInfo>> allTopics = new HashMap<>();
+        for (final TopicPartition partition : authorizedTopics) {
+            allTopics
+                    .put(
+                            partition.topic(),
+                            Collections.singletonList(new PartitionInfo(partition.topic(), 0, null, null, null))
+                    );
+        }
+
+        for (final TopicPartition partition : unauthorizedTopics) {
+            allTopics
+                    .put(
+                            partition.topic(),
+                            Collections.singletonList(new PartitionInfo(partition.topic(), 0, null, null, null))
+                    );
+        }
+
+        when(consumerMock.listTopics()).thenReturn(allTopics);
+
+        for (final TopicPartition partition : unauthorizedTopics) {
+            when(consumerMock.partitionsFor(partition.topic()))
+                    .thenThrow(new TopicAuthorizationException(String.valueOf(Collections.singletonList(partition))));
+        }
+
+        for (final TopicPartition partition : authorizedTopics) {
+            when(consumerMock.partitionsFor(partition.topic()))
+                    .thenReturn(Collections.singletonList(new PartitionInfo(partition.topic(), 0, null, null, null)));
+        }
+
+        final Map<TopicPartition, Long> beginningOffsets = new HashMap<>();
+        final Map<TopicPartition, Long> endOffsets = new HashMap<>();
+
+        for (final TopicPartition partition : authorizedTopics) {
+            beginningOffsets.put(partition, 10L);
+            endOffsets.put(partition, 100L);
+        }
+
+        final Duration duration = Duration.ofSeconds(60);
+        when(consumerMock.beginningOffsets(authorizedTopics, duration)).thenReturn(beginningOffsets);
+        when(consumerMock.endOffsets(authorizedTopics, duration)).thenReturn(endOffsets);
+
+        return consumerMock;
+    }
+
+}


### PR DESCRIPTION
## Refactor of KafkaQueryProcessor into separate class KafkaQueryImpl

Idea was to replace `poll(timeout)` method completely since it was causing problems.

I think before the Kafka query subscribed to a pattern and used `poll()` to trigger to populate consumer meta data or something to this nature. Then that meta data was used to get offsets for the methods. 

The topic subscription regex pattern was updated if user had no authorization for a topic, using a list of unauthorized topics which also was unreliable.

Instead we now use the `listTopics()` method to list all topics the user has access to and then filter topics them using a regex pattern. There is also a safe guard to check if topic causes an `TopicAuthorizationException` to filter it from the final topics. 

Then finally we use the same logic as before to find out offsets from the resulting topic list. 
As before the when continuously processing the end offset calculation is triggered on every call, if not the cached end offset is used instead.

## Blockers
- There was no testing for these Kafka operations, created some mock tests but I don't think they fully cover the changes.
- It seemed to me that the consumer was not used outside of the class and for that reason the subscription, polling and assignments were unnecessary.  The required meta data was available without these steps but this might be a misunderstanding on my part. 
- Was not able to test in local development environment or in QA yet