### PR TITLE
Implement support for new epoch columns to StreamDBClient queries

### DIFF
--- a/src/main/java/com/teragrep/pth_06/planner/ArchiveQuery.java
+++ b/src/main/java/com/teragrep/pth_06/planner/ArchiveQuery.java
@@ -46,11 +46,9 @@
 package com.teragrep.pth_06.planner;
 
 import org.apache.spark.sql.connector.metric.CustomTaskMetric;
-import org.jooq.Record10;
+import org.jooq.Record9;
 import org.jooq.Result;
 import org.jooq.types.ULong;
-
-import java.sql.Date;
 
 /**
  * <h1>Archive Query</h1> Interface for an archive query.
@@ -60,7 +58,7 @@ import java.sql.Date;
  */
 public interface ArchiveQuery {
 
-    public abstract Result<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> processBetweenUnixEpochHours(
+    public abstract Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> processBetweenUnixEpochHours(
             long startHour,
             long endHour
     );

--- a/src/main/java/com/teragrep/pth_06/planner/ArchiveQueryProcessor.java
+++ b/src/main/java/com/teragrep/pth_06/planner/ArchiveQueryProcessor.java
@@ -145,7 +145,7 @@ public class ArchiveQueryProcessor implements ArchiveQuery {
      * @return Data between start hour and end hour.
      */
     @Override
-    public Result<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> processBetweenUnixEpochHours(
+    public Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> processBetweenUnixEpochHours(
             long startHour,
             long endHour
     ) {

--- a/src/main/java/com/teragrep/pth_06/planner/NestedTopNQuery.java
+++ b/src/main/java/com/teragrep/pth_06/planner/NestedTopNQuery.java
@@ -59,6 +59,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import static com.teragrep.pth_06.jooq.generated.journaldb.Journaldb.JOURNALDB;
+import static org.jooq.impl.DSL.coalesce;
 
 public final class NestedTopNQuery {
 
@@ -81,7 +82,7 @@ public final class NestedTopNQuery {
             JOURNALDB.LOGFILE.ID.as(id),
             GetArchivedObjectsFilterTable.directory.as(directory),
             GetArchivedObjectsFilterTable.stream.as(stream),
-            logtimeFunction.asField().as(logtime)
+            coalesce(JOURNALDB.LOGFILE.EPOCH_HOUR, logtimeFunction.asField()).as(logtime)
     };
 
     public NestedTopNQuery(final StreamDBClient streamDBClient, final boolean isDebug) {

--- a/src/main/java/com/teragrep/pth_06/planner/NestedTopNQuery.java
+++ b/src/main/java/com/teragrep/pth_06/planner/NestedTopNQuery.java
@@ -118,8 +118,10 @@ public final class NestedTopNQuery {
         }
 
         logger.debug("NestedTopNQuery.getTableStatement exit");
+        final Field<Date> logdateFunction = DSL
+                .field("CAST(FROM_UNIXTIME({0}) as DATE)", Date.class, JOURNALDB.LOGFILE.EPOCH_HOUR);
         return selectOnConditionStep
-                .where(JOURNALDB.LOGFILE.LOGDATE.eq(day).and(journaldbConditionArg))
+                .where(coalesce(logdateFunction, JOURNALDB.LOGFILE.LOGDATE).eq(day).and(journaldbConditionArg))
                 .orderBy(logtimeForOrderBy, JOURNALDB.LOGFILE.ID.asc())
                 .asTable(innerTable);
     }

--- a/src/main/java/com/teragrep/pth_06/planner/NestedTopNQuery.java
+++ b/src/main/java/com/teragrep/pth_06/planner/NestedTopNQuery.java
@@ -119,7 +119,10 @@ public final class NestedTopNQuery {
 
         logger.debug("NestedTopNQuery.getTableStatement exit");
         final Field<Date> logdateFunction = DSL
-                .field("CAST(FROM_UNIXTIME({0}) as DATE)", Date.class, JOURNALDB.LOGFILE.EPOCH_HOUR);
+                .field(
+                        "CAST(date_add('1970-01-01', interval {0} second) as DATE)", Date.class,
+                        JOURNALDB.LOGFILE.EPOCH_HOUR
+                );
         return selectOnConditionStep
                 .where(coalesce(logdateFunction, JOURNALDB.LOGFILE.LOGDATE).eq(day).and(journaldbConditionArg))
                 .orderBy(logtimeForOrderBy, JOURNALDB.LOGFILE.ID.asc())

--- a/src/main/java/com/teragrep/pth_06/planner/NestedTopNQuery.java
+++ b/src/main/java/com/teragrep/pth_06/planner/NestedTopNQuery.java
@@ -59,7 +59,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import static com.teragrep.pth_06.jooq.generated.journaldb.Journaldb.JOURNALDB;
-import static org.jooq.impl.DSL.coalesce;
 
 public final class NestedTopNQuery {
 
@@ -68,9 +67,6 @@ public final class NestedTopNQuery {
     private final StreamDBClient streamDBClient;
     private final String innerTableName = "limited";
     private final Table<Record> innerTable = DSL.table(DSL.name(innerTableName));
-
-    // TODO refactor: heavily database session dependant: create synthetic logtime field, based on the path
-    private final SafeLogtimeFunction logtimeFunction = new SafeLogtimeFunction(JOURNALDB.LOGFILE.PATH);
 
     private final Field<ULong> id = DSL.field(DSL.name(innerTableName, "id"), ULong.class);
     private final Field<String> directory = DSL.field(DSL.name(innerTableName, "directory"), String.class);
@@ -82,7 +78,7 @@ public final class NestedTopNQuery {
             JOURNALDB.LOGFILE.ID.as(id),
             GetArchivedObjectsFilterTable.directory.as(directory),
             GetArchivedObjectsFilterTable.stream.as(stream),
-            coalesce(JOURNALDB.LOGFILE.EPOCH_HOUR, logtimeFunction.asField()).as(logtime)
+            JOURNALDB.LOGFILE.EPOCH_HOUR.as(logtime)
     };
 
     public NestedTopNQuery(final StreamDBClient streamDBClient, final boolean isDebug) {
@@ -124,7 +120,7 @@ public final class NestedTopNQuery {
                         JOURNALDB.LOGFILE.EPOCH_HOUR
                 );
         return selectOnConditionStep
-                .where(coalesce(logdateFunction, JOURNALDB.LOGFILE.LOGDATE).eq(day).and(journaldbConditionArg))
+                .where(logdateFunction.eq(day).and(journaldbConditionArg))
                 .orderBy(logtimeForOrderBy, JOURNALDB.LOGFILE.ID.asc())
                 .asTable(innerTable);
     }
@@ -151,17 +147,17 @@ public final class NestedTopNQuery {
             return false;
         }
         final NestedTopNQuery that = (NestedTopNQuery) o;
-        return Objects.equals(logger, that.logger) && Objects.equals(streamDBClient, that.streamDBClient) && Objects
-                .equals(innerTableName, that.innerTableName) && Objects.equals(innerTable, that.innerTable)
-                && Objects.equals(logtimeFunction, that.logtimeFunction) && Objects.equals(id, that.id) && Objects.equals(directory, that.directory) && Objects.equals(stream, that.stream) && Objects.equals(logtime, that.logtime) && Objects.equals(logtimeForOrderBy, that.logtimeForOrderBy) && Objects.deepEquals(resultFields, that.resultFields);
+        return Objects.equals(logger, that.logger) && Objects
+                .equals(streamDBClient, that.streamDBClient) && Objects.equals(innerTableName, that.innerTableName)
+                && Objects.equals(innerTable, that.innerTable) && Objects.equals(id, that.id) && Objects.equals(directory, that.directory) && Objects.equals(stream, that.stream) && Objects.equals(logtime, that.logtime) && Objects.equals(logtimeForOrderBy, that.logtimeForOrderBy) && Objects.deepEquals(resultFields, that.resultFields);
     }
 
     @Override
     public int hashCode() {
         return Objects
                 .hash(
-                        logger, streamDBClient, innerTableName, innerTable, logtimeFunction, id, directory, stream,
-                        logtime, logtimeForOrderBy, Arrays.hashCode(resultFields)
+                        logger, streamDBClient, innerTableName, innerTable, id, directory, stream, logtime,
+                        logtimeForOrderBy, Arrays.hashCode(resultFields)
                 );
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/NestedTopNQuery.java
+++ b/src/main/java/com/teragrep/pth_06/planner/NestedTopNQuery.java
@@ -71,14 +71,14 @@ public final class NestedTopNQuery {
     private final Field<ULong> id = DSL.field(DSL.name(innerTableName, "id"), ULong.class);
     private final Field<String> directory = DSL.field(DSL.name(innerTableName, "directory"), String.class);
     private final Field<String> stream = DSL.field(DSL.name(innerTableName, "stream"), String.class);
-    private final Field<Long> logtime = DSL.field(DSL.name(innerTableName, "logtime"), Long.class);
-    private final Field<Long> logtimeForOrderBy = DSL.field("logtime", Long.class);
+    private final Field<Long> epochHour = DSL.field(DSL.name(innerTableName, "epochHour"), Long.class);
+    private final Field<Long> epochHourForOrderBy = DSL.field("epochHour", Long.class);
 
     private final SelectField<?>[] resultFields = {
             JOURNALDB.LOGFILE.ID.as(id),
             GetArchivedObjectsFilterTable.directory.as(directory),
             GetArchivedObjectsFilterTable.stream.as(stream),
-            JOURNALDB.LOGFILE.EPOCH_HOUR.as(logtime)
+            JOURNALDB.LOGFILE.EPOCH_HOUR.as(epochHour)
     };
 
     public NestedTopNQuery(final StreamDBClient streamDBClient, final boolean isDebug) {
@@ -121,12 +121,12 @@ public final class NestedTopNQuery {
                 );
         return selectOnConditionStep
                 .where(logdateFunction.eq(day).and(journaldbConditionArg))
-                .orderBy(logtimeForOrderBy, JOURNALDB.LOGFILE.ID.asc())
+                .orderBy(epochHourForOrderBy, JOURNALDB.LOGFILE.ID.asc())
                 .asTable(innerTable);
     }
 
     public Field<Long> logtime() {
-        return logtime;
+        return epochHour;
     }
 
     public Field<String> stream() {
@@ -149,15 +149,15 @@ public final class NestedTopNQuery {
         final NestedTopNQuery that = (NestedTopNQuery) o;
         return Objects.equals(logger, that.logger) && Objects
                 .equals(streamDBClient, that.streamDBClient) && Objects.equals(innerTableName, that.innerTableName)
-                && Objects.equals(innerTable, that.innerTable) && Objects.equals(id, that.id) && Objects.equals(directory, that.directory) && Objects.equals(stream, that.stream) && Objects.equals(logtime, that.logtime) && Objects.equals(logtimeForOrderBy, that.logtimeForOrderBy) && Objects.deepEquals(resultFields, that.resultFields);
+                && Objects.equals(innerTable, that.innerTable) && Objects.equals(id, that.id) && Objects.equals(directory, that.directory) && Objects.equals(stream, that.stream) && Objects.equals(epochHour, that.epochHour) && Objects.equals(epochHourForOrderBy, that.epochHourForOrderBy) && Objects.deepEquals(resultFields, that.resultFields);
     }
 
     @Override
     public int hashCode() {
         return Objects
                 .hash(
-                        logger, streamDBClient, innerTableName, innerTable, id, directory, stream, logtime,
-                        logtimeForOrderBy, Arrays.hashCode(resultFields)
+                        logger, streamDBClient, innerTableName, innerTable, id, directory, stream, epochHour,
+                        epochHourForOrderBy, Arrays.hashCode(resultFields)
                 );
     }
 }

--- a/src/main/java/com/teragrep/pth_06/planner/SliceTable.java
+++ b/src/main/java/com/teragrep/pth_06/planner/SliceTable.java
@@ -53,7 +53,6 @@ import org.jooq.types.ULong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.Date;
 import java.util.Objects;
 
 public final class SliceTable {
@@ -67,7 +66,6 @@ public final class SliceTable {
     public static final Field<String> directory = DSL.field(DSL.name(sliceTableName, "directory"), String.class);
     public static final Field<String> stream = DSL.field(DSL.name(sliceTableName, "stream"), String.class);
     public static final Field<String> host = DSL.field(DSL.name(sliceTableName, "host"), String.class);
-    public static final Field<Date> logdate = DSL.field(DSL.name(sliceTableName, "logdate"), Date.class);
     public static final Field<String> bucket = DSL.field(DSL.name(sliceTableName, "bucket"), String.class);
     public static final Field<String> path = DSL.field(DSL.name(sliceTableName, "path"), String.class);
     public static final Field<Long> logtime = DSL.field(DSL.name(sliceTableName, "logtime"), Long.class);
@@ -94,7 +92,7 @@ public final class SliceTable {
             dropTableStep.execute();
         }
         try (
-                final CreateTableColumnStep createTableStep = ctx.createTemporaryTable(SLICE_TABLE).columns(id, directory, stream, host, logdate, bucket, path, logtime, filesize, uncompressedFilesize)
+                final CreateTableColumnStep createTableStep = ctx.createTemporaryTable(SLICE_TABLE).columns(id, directory, stream, host, bucket, path, logtime, filesize, uncompressedFilesize)
         ) {
             if (isLogSQL) {
                 LOGGER

--- a/src/main/java/com/teragrep/pth_06/planner/StreamDBClient.java
+++ b/src/main/java/com/teragrep/pth_06/planner/StreamDBClient.java
@@ -205,7 +205,7 @@ public final class StreamDBClient implements AutoCloseable {
     public int pullToSliceTable(Date day) {
         LOGGER.debug("StreamDBClient.pullToSliceTable called for date <{}>", day);
         final Field<Date> logdateFunction = DSL
-                .field("CAST(FROM_UNIXTIME({0}) as DATETIME)", Date.class, JOURNALDB.LOGFILE.EPOCH_HOUR);
+                .field("CAST(FROM_UNIXTIME({0}) as DATE)", Date.class, JOURNALDB.LOGFILE.EPOCH_HOUR);
         SelectConditionStep<Record1<Integer>> corruptedLogfilesField = DSL
                 .selectOne()
                 .from(JOURNALDB.CORRUPTED_ARCHIVE)

--- a/src/main/java/com/teragrep/pth_06/planner/StreamDBClient.java
+++ b/src/main/java/com/teragrep/pth_06/planner/StreamDBClient.java
@@ -73,8 +73,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import static com.teragrep.pth_06.jooq.generated.journaldb.Journaldb.JOURNALDB;
 
-import static org.jooq.impl.DSL.coalesce;
-
 // https://stackoverflow.com/questions/33657391/qualifying-a-temporary-table-column-name-in-jooq
 // https://www.jooq.org/doc/latest/manual/sql-building/dynamic-sql/
 
@@ -216,9 +214,7 @@ public final class StreamDBClient implements AutoCloseable {
         SelectOnConditionStep<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> select = ctx
                 .select(
                         JOURNALDB.LOGFILE.ID, nestedTopNQuery.directory(), nestedTopNQuery.stream(),
-                        JOURNALDB.HOST.NAME, coalesce(
-                                logdateFunction, JOURNALDB.LOGFILE.LOGDATE
-                        ), JOURNALDB.BUCKET.NAME, JOURNALDB.LOGFILE.PATH,
+                        JOURNALDB.HOST.NAME, logdateFunction, JOURNALDB.BUCKET.NAME, JOURNALDB.LOGFILE.PATH,
                         nestedTopNQuery.logtime(), JOURNALDB.LOGFILE.FILE_SIZE, JOURNALDB.LOGFILE.UNCOMPRESSED_FILE_SIZE
                 )
                 .from(nestedTopNQuery.getTableStatement(journaldbCondition, day))

--- a/src/main/java/com/teragrep/pth_06/planner/StreamDBClient.java
+++ b/src/main/java/com/teragrep/pth_06/planner/StreamDBClient.java
@@ -73,6 +73,8 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import static com.teragrep.pth_06.jooq.generated.journaldb.Journaldb.JOURNALDB;
 
+import static org.jooq.impl.DSL.coalesce;
+
 // https://stackoverflow.com/questions/33657391/qualifying-a-temporary-table-column-name-in-jooq
 // https://www.jooq.org/doc/latest/manual/sql-building/dynamic-sql/
 
@@ -202,7 +204,8 @@ public final class StreamDBClient implements AutoCloseable {
 
     public int pullToSliceTable(Date day) {
         LOGGER.debug("StreamDBClient.pullToSliceTable called for date <{}>", day);
-
+        final Field<Date> logdateFunction = DSL
+                .field("CAST(FROM_UNIXTIME({0}) as DATETIME)", Date.class, JOURNALDB.LOGFILE.EPOCH_HOUR);
         SelectConditionStep<Record1<Integer>> corruptedLogfilesField = DSL
                 .selectOne()
                 .from(JOURNALDB.CORRUPTED_ARCHIVE)
@@ -210,7 +213,9 @@ public final class StreamDBClient implements AutoCloseable {
         SelectOnConditionStep<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> select = ctx
                 .select(
                         JOURNALDB.LOGFILE.ID, nestedTopNQuery.directory(), nestedTopNQuery.stream(),
-                        JOURNALDB.HOST.NAME, JOURNALDB.LOGFILE.LOGDATE, JOURNALDB.BUCKET.NAME, JOURNALDB.LOGFILE.PATH,
+                        JOURNALDB.HOST.NAME, coalesce(
+                                logdateFunction, JOURNALDB.LOGFILE.LOGDATE
+                        ), JOURNALDB.BUCKET.NAME, JOURNALDB.LOGFILE.PATH,
                         nestedTopNQuery.logtime(), JOURNALDB.LOGFILE.FILE_SIZE, JOURNALDB.LOGFILE.UNCOMPRESSED_FILE_SIZE
                 )
                 .from(nestedTopNQuery.getTableStatement(journaldbCondition, day))

--- a/src/main/java/com/teragrep/pth_06/planner/StreamDBClient.java
+++ b/src/main/java/com/teragrep/pth_06/planner/StreamDBClient.java
@@ -202,20 +202,15 @@ public final class StreamDBClient implements AutoCloseable {
 
     public int pullToSliceTable(Date day) {
         LOGGER.debug("StreamDBClient.pullToSliceTable called for date <{}>", day);
-        final Field<Date> logdateFunction = DSL
-                .field(
-                        "CAST(date_add('1970-01-01', interval {0} second) as DATE)", Date.class,
-                        JOURNALDB.LOGFILE.EPOCH_HOUR
-                );
         SelectConditionStep<Record1<Integer>> corruptedLogfilesField = DSL
                 .selectOne()
                 .from(JOURNALDB.CORRUPTED_ARCHIVE)
                 .where(JOURNALDB.LOGFILE.ID.eq(JOURNALDB.CORRUPTED_ARCHIVE.LOGFILE_ID));
-        SelectOnConditionStep<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> select = ctx
+        SelectOnConditionStep<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> select = ctx
                 .select(
                         JOURNALDB.LOGFILE.ID, nestedTopNQuery.directory(), nestedTopNQuery.stream(),
-                        JOURNALDB.HOST.NAME, logdateFunction, JOURNALDB.BUCKET.NAME, JOURNALDB.LOGFILE.PATH,
-                        nestedTopNQuery.logtime(), JOURNALDB.LOGFILE.FILE_SIZE, JOURNALDB.LOGFILE.UNCOMPRESSED_FILE_SIZE
+                        JOURNALDB.HOST.NAME, JOURNALDB.BUCKET.NAME, JOURNALDB.LOGFILE.PATH, nestedTopNQuery.logtime(),
+                        JOURNALDB.LOGFILE.FILE_SIZE, JOURNALDB.LOGFILE.UNCOMPRESSED_FILE_SIZE
                 )
                 .from(nestedTopNQuery.getTableStatement(journaldbCondition, day))
                 .join(JOURNALDB.LOGFILE)
@@ -301,7 +296,7 @@ public final class StreamDBClient implements AutoCloseable {
         return deletedRowsCount;
     }
 
-    Result<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> getHourRange(
+    Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> getHourRange(
             long excludedStartHour,
             long includedEndHour
     ) {
@@ -310,11 +305,10 @@ public final class StreamDBClient implements AutoCloseable {
                         "StreamDBClient.getHourRange called excludedStartHour <{}> includedEndHour <{}>",
                         excludedStartHour, includedEndHour
                 );
-        Result<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> result = ctx
+        Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> result = ctx
                 .select(
-                        SliceTable.id, SliceTable.directory, SliceTable.stream, SliceTable.host, SliceTable.logdate,
-                        SliceTable.bucket, SliceTable.path, SliceTable.logtime, SliceTable.filesize,
-                        SliceTable.uncompressedFilesize
+                        SliceTable.id, SliceTable.directory, SliceTable.stream, SliceTable.host, SliceTable.bucket,
+                        SliceTable.path, SliceTable.logtime, SliceTable.filesize, SliceTable.uncompressedFilesize
                 )
                 .from(SliceTable.SLICE_TABLE)
                 .where(SliceTable.logtime.greaterThan(excludedStartHour).and(SliceTable.logtime.lessOrEqual(includedEndHour)).and(SliceTable.logtime.lessThan(includeBeforeEpoch))).fetch();

--- a/src/main/java/com/teragrep/pth_06/planner/StreamDBClient.java
+++ b/src/main/java/com/teragrep/pth_06/planner/StreamDBClient.java
@@ -205,7 +205,10 @@ public final class StreamDBClient implements AutoCloseable {
     public int pullToSliceTable(Date day) {
         LOGGER.debug("StreamDBClient.pullToSliceTable called for date <{}>", day);
         final Field<Date> logdateFunction = DSL
-                .field("CAST(FROM_UNIXTIME({0}) as DATE)", Date.class, JOURNALDB.LOGFILE.EPOCH_HOUR);
+                .field(
+                        "CAST(date_add('1970-01-01', interval {0} second) as DATE)", Date.class,
+                        JOURNALDB.LOGFILE.EPOCH_HOUR
+                );
         SelectConditionStep<Record1<Integer>> corruptedLogfilesField = DSL
                 .selectOne()
                 .from(JOURNALDB.CORRUPTED_ARCHIVE)

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/EarliestCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/EarliestCondition.java
@@ -46,9 +46,8 @@
 package com.teragrep.pth_06.planner.walker.conditions;
 
 import org.jooq.Condition;
+import org.jooq.types.ULong;
 
-import java.sql.Date;
-import java.time.Instant;
 import java.util.Objects;
 
 import static com.teragrep.pth_06.jooq.generated.journaldb.Journaldb.JOURNALDB;
@@ -62,28 +61,8 @@ public final class EarliestCondition implements QueryCondition {
     }
 
     public Condition condition() {
-        // SQL connection uses localTime in the session, so we use unix to come over the conversions
-        // hour based files are being used so earliest needs conversion to the point of the last hour
-        final long earliestFromElement = Long.parseLong(value);
-        final long earliestEpochHour = earliestFromElement - earliestFromElement % 3600;
-        final Instant instant = Instant.ofEpochSecond(earliestEpochHour);
-        final java.sql.Date timeQualifier = new Date(instant.toEpochMilli());
-        Condition condition;
-        condition = JOURNALDB.LOGFILE.LOGDATE.greaterOrEqual(timeQualifier);
-        condition = condition
-                .and(
-                        "UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H'))"
-                                + " >= " + instant.getEpochSecond()
-                );
-        // raw SQL used here since following not supported for mariadb:
-        // queryCondition = queryCondition.and(toTimestamp(
-        // regexpReplaceAll(JOURNALDB.LOGFILE.PATH, "((^.*\\/.*-)|(\\.log\\.gz.*))", ""),
-        // "YYYYMMDDHH24").lessOrEqual(Timestamp.from(instant)));
-        // to match
-        // 2021/09-27/sc-99-99-14-244/messages/messages-2021092722.gz.4
-        // 2018/04-29/sc-99-99-14-245/f17/f17.logGLOB-2018042900.log.gz
-        // NOTE uses literal path
-        return condition;
+        // epoch_hour value is used for both date and hour based filtering.
+        return JOURNALDB.LOGFILE.EPOCH_HOUR.greaterOrEqual(ULong.valueOf(value));
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/LatestCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/LatestCondition.java
@@ -46,9 +46,8 @@
 package com.teragrep.pth_06.planner.walker.conditions;
 
 import org.jooq.Condition;
+import org.jooq.types.ULong;
 
-import java.sql.Date;
-import java.time.Instant;
 import java.util.Objects;
 
 import static com.teragrep.pth_06.jooq.generated.journaldb.Journaldb.JOURNALDB;
@@ -62,26 +61,8 @@ public final class LatestCondition implements QueryCondition {
     }
 
     public Condition condition() {
-        // SQL connection uses localTime in the session, so we use unix to come over the conversions
-        final long epochSeconds = Long.parseLong(value);
-        final Instant instant = Instant.ofEpochSecond(epochSeconds);
-        final java.sql.Date timeQualifier = new Date(instant.toEpochMilli());
-        Condition condition;
-        condition = JOURNALDB.LOGFILE.LOGDATE.lessOrEqual(timeQualifier);
-        condition = condition
-                .and(
-                        "UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H'))"
-                                + " <= " + instant.getEpochSecond()
-                );
-        // raw SQL used here since following not supported for mariadb:
-        // queryCondition = queryCondition.and(toTimestamp(
-        // regexpReplaceAll(JOURNALDB.LOGFILE.PATH, "((^.*\\/.*-)|(\\.log\\.gz.*))", ""),
-        // "YYYYMMDDHH24").lessOrEqual(Timestamp.from(instant)));
-        // to match
-        // 2021/09-27/sc-99-99-14-244/messages/messages-2021092722.gz.4
-        // 2018/04-29/sc-99-99-14-245/f17/f17.logGLOB-2018042900.log.gz
-        // NOTE uses literal path
-        return condition;
+        // epoch_hour value is used for both date and hour based filtering.
+        return JOURNALDB.LOGFILE.EPOCH_HOUR.lessOrEqual(ULong.valueOf(value));
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/scheduler/ArchiveRangeProcessor.java
+++ b/src/main/java/com/teragrep/pth_06/scheduler/ArchiveRangeProcessor.java
@@ -50,13 +50,12 @@ import com.teragrep.pth_06.planner.ArchiveQuery;
 import com.teragrep.pth_06.planner.offset.DatasourceOffset;
 import org.apache.spark.sql.connector.read.streaming.Offset;
 import org.jooq.Record;
-import org.jooq.Record10;
+import org.jooq.Record9;
 import org.jooq.Result;
 import org.jooq.types.ULong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.Date;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -75,7 +74,7 @@ public final class ArchiveRangeProcessor implements RangeProcessor {
 
         List<BatchUnit> batchUnits = new ArrayList<>();
 
-        Result<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> result = aq
+        Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> result = aq
                 .processBetweenUnixEpochHours(
                         ((DatasourceOffset) start).getArchiveOffset().offset(),
                         ((DatasourceOffset) end).getArchiveOffset().offset()
@@ -84,19 +83,19 @@ public final class ArchiveRangeProcessor implements RangeProcessor {
         for (Record r : result) {
             // uncompressed size can be null
             long uncompressedSize = -1L;
-            if (r.get(9) != null) {
-                uncompressedSize = r.get(9, Long.class);
+            if (r.get(8) != null) {
+                uncompressedSize = r.get(8, Long.class);
             }
 
             batchUnits
                     .add(new BatchUnit(new ArchiveS3ObjectMetadata(r.get(0, String.class), // id
-                            r.get(5, String.class), // bucket
-                            r.get(6, String.class), // path
+                            r.get(4, String.class), // bucket
+                            r.get(5, String.class), // path
                             r.get(1, String.class), // directory
                             r.get(2, String.class), // stream
                             r.get(3, String.class), // host
-                            r.get(7, Long.class), // logtime
-                            r.get(8, Long.class), // compressedSize
+                            r.get(6, Long.class), // logtime
+                            r.get(7, Long.class), // compressedSize
                             uncompressedSize // uncompressedSize
                     )));
         }

--- a/src/test/java/com/teragrep/pth_06/XmlToSqlTest.java
+++ b/src/test/java/com/teragrep/pth_06/XmlToSqlTest.java
@@ -51,9 +51,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.Date;
-import java.time.Instant;
-
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class XmlToSqlTest {
@@ -161,19 +159,15 @@ public class XmlToSqlTest {
         String e;
         String result;
         q = "<OR><AND><AND><index value=\"haproxy\" operation=\"NOT_EQUALS\"/><sourcetype value=\"example:haproxy:haproxy\" operation=\"EQUALS\"/></AND><host value=\"loadbalancer.example.com\" operation=\"EQUALS\"/></AND><AND><AND><AND><index value=\"*\" operation=\"EQUALS\"/><host value=\"firewall.example.com\" operation=\"EQUALS\"/></AND><earliest value=\"1611612000\" operation=\"GE\"/></AND><indexstring value=\"Denied\" /></AND></OR>";
-        // Add time ranges
-        Instant fromTime = Instant.ofEpochSecond(1611612000);
-        Date fromDate = new Date(fromTime.toEpochMilli());
+
         LOGGER.debug("Journal-DB");
         e = "(\n" + "  (\n" + "    not (\"getArchivedObjects_filter_table\".\"directory\" like 'haproxy')\n"
                 + "    and \"getArchivedObjects_filter_table\".\"stream\" like 'example:haproxy:haproxy'\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'loadbalancer.example.com'\n" + "  )\n"
                 + "  or (\n" + "    true\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'firewall.example.com'\n"
-                + "    and \"journaldb\".\"logfile\".\"logdate\" >= date '" + fromDate + "'\n"
-                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= "
-                + fromTime.getEpochSecond() + ")\n" + "  )\n" + ")";
-        result = parser.fromString(q, false).toString();
+                + "    and \"journaldb\".\"logfile\".\"epoch_hour\" >= 1611612000\n" + "  )\n" + ")";
+        result = assertDoesNotThrow(() -> parser.fromString(q, false).toString());
         LOGGER.debug("Query=" + q);
         LOGGER.debug("Expected=" + e);
         LOGGER.debug("Result=" + result);
@@ -181,24 +175,20 @@ public class XmlToSqlTest {
     }
 
     @Test
-    void fromStringTest_JournalDB_OrTimestampLTE() throws Exception {
-        String q;
-        String e;
-        String result;
+    void fromStringTest_JournalDB_OrTimestampLTE() {
+        final String q;
+        final String e;
+        final String result;
         q = "<OR><AND><AND><index value=\"haproxy\" operation=\"NOT_EQUALS\"/><sourcetype value=\"example:haproxy:haproxy\" operation=\"EQUALS\"/></AND><host value=\"loadbalancer.example.com\" operation=\"EQUALS\"/></AND><AND><AND><AND><index value=\"*\" operation=\"EQUALS\"/><host value=\"firewall.example.com\" operation=\"EQUALS\"/></AND><latest value=\"1611611999\" operation=\"LE\"/></AND><indexstring value=\"Denied\" /></AND></OR>";
-        // Add time ranges
-        Instant fromTime = Instant.ofEpochSecond(1611611999);
-        Date fromDate = new Date(fromTime.toEpochMilli());
+
         LOGGER.debug("Journal-DB");
         e = "(\n" + "  (\n" + "    not (\"getArchivedObjects_filter_table\".\"directory\" like 'haproxy')\n"
                 + "    and \"getArchivedObjects_filter_table\".\"stream\" like 'example:haproxy:haproxy'\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'loadbalancer.example.com'\n" + "  )\n"
                 + "  or (\n" + "    true\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'firewall.example.com'\n"
-                + "    and \"journaldb\".\"logfile\".\"logdate\" <= date '" + fromDate + "'\n"
-                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= "
-                + fromTime.getEpochSecond() + ")\n" + "  )\n" + ")";
-        result = parser.fromString(q, false).toString();
+                + "    and \"journaldb\".\"logfile\".\"epoch_hour\" <= 1611611999\n" + "  )\n" + ")";
+        result = assertDoesNotThrow(() -> parser.fromString(q, false).toString());
         LOGGER.debug("Query=" + q);
         LOGGER.debug("Expected=" + e);
         LOGGER.debug("Result=" + result);
@@ -206,28 +196,20 @@ public class XmlToSqlTest {
     }
 
     @Test
-    void fromStringTest_JournalDB_OrTimestampBetween() throws Exception {
-        String q;
-        String e;
-        String result;
+    void fromStringTest_JournalDB_OrTimestampBetween() {
+        final String q;
+        final String e;
+        final String result;
         q = "<OR><AND><AND><index value=\"haproxy\" operation=\"NOT_EQUALS\"/><sourcetype value=\"example:haproxy:haproxy\" operation=\"EQUALS\"/></AND><host value=\"loadbalancer.example.com\" operation=\"EQUALS\"/></AND><AND><AND><AND><AND><index value=\"*\" operation=\"EQUALS\"/><host value=\"firewall.example.com\" operation=\"EQUALS\"/></AND><earliest value=\"1611657303\" operation=\"GE\"/></AND><latest value=\"1619437701\" operation=\"LE\"/></AND><indexstring value=\"Denied\" /></AND></OR>";
-        // Add time ranges
-        Instant fromTime = Instant.ofEpochSecond(1611655200);
-        Date fromDate = new Date(fromTime.toEpochMilli());
-        Instant toTime = Instant.ofEpochSecond(1619437701);
-        Date toDate = new Date(toTime.toEpochMilli());
+
         e = "(\n" + "  (\n" + "    not (\"getArchivedObjects_filter_table\".\"directory\" like 'haproxy')\n"
                 + "    and \"getArchivedObjects_filter_table\".\"stream\" like 'example:haproxy:haproxy'\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'loadbalancer.example.com'\n" + "  )\n"
                 + "  or (\n" + "    true\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'firewall.example.com'\n"
-                + "    and \"journaldb\".\"logfile\".\"logdate\" >= date '" + fromDate + "'\n"
-                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= "
-                + fromTime.getEpochSecond() + ")\n" + "    and \"journaldb\".\"logfile\".\"logdate\" <= date '" + toDate
-                + "'\n"
-                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= "
-                + toTime.getEpochSecond() + ")\n" + "  )\n" + ")";
-        result = parser.fromString(q, false).toString();
+                + "    and \"journaldb\".\"logfile\".\"epoch_hour\" >= 1611657303\n"
+                + "    and \"journaldb\".\"logfile\".\"epoch_hour\" <= 1619437701\n" + "  )\n" + ")";
+        result = assertDoesNotThrow(() -> parser.fromString(q, false).toString());
         LOGGER.debug("Query=" + q);
         LOGGER.debug("Expected=" + e);
         LOGGER.debug("Result=" + result);
@@ -235,27 +217,18 @@ public class XmlToSqlTest {
     }
 
     @Test
-    void fromStringTest_JournalDB_AndTimestampBetween() throws Exception {
-        String q;
-        String e;
-        String result;
+    void fromStringTest_JournalDB_AndTimestampBetween() {
+        final String q;
+        final String e;
+        final String result;
         q = "<AND><AND><AND><host value=\"sc-99-99-14-25\" operation=\"EQUALS\"/><index value=\"cpu\" operation=\"EQUALS\"/></AND><sourcetype value=\"log:cpu:0\" operation=\"EQUALS\"/></AND><AND><earliest value=\"0\" operation=\"GE\"/><latest value=\"1893491420\" operation=\"LE\"/></AND></AND>";
-        // Add time ranges
-        Instant fromTime = Instant.ofEpochSecond(0);
-        Date fromDate = new Date(fromTime.toEpochMilli());
-        Instant toTime = Instant.ofEpochSecond(1893491420);
-        Date toDate = new Date(toTime.toEpochMilli());
 
         e = "(\n" + "  \"getArchivedObjects_filter_table\".\"host\" like 'sc-99-99-14-25'\n"
                 + "  and \"getArchivedObjects_filter_table\".\"directory\" like 'cpu'\n"
                 + "  and \"getArchivedObjects_filter_table\".\"stream\" like 'log:cpu:0'\n"
-                + "  and \"journaldb\".\"logfile\".\"logdate\" >= date '" + fromDate + "'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= "
-                + fromTime.getEpochSecond() + ")\n" + "  and \"journaldb\".\"logfile\".\"logdate\" <= date '" + toDate
-                + "'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= "
-                + toTime.getEpochSecond() + ")\n" + ")";
-        result = parser.fromString(q, false).toString();
+                + "  and \"journaldb\".\"logfile\".\"epoch_hour\" >= 0\n"
+                + "  and \"journaldb\".\"logfile\".\"epoch_hour\" <= 1893491420\n" + ")";
+        result = assertDoesNotThrow(() -> parser.fromString(q, false).toString());
         LOGGER.debug("Query=" + q);
         LOGGER.debug("Expected=" + e);
         LOGGER.debug("Result=" + result);

--- a/src/test/java/com/teragrep/pth_06/planner/MockArchiveQueryProcessor.java
+++ b/src/test/java/com/teragrep/pth_06/planner/MockArchiveQueryProcessor.java
@@ -54,7 +54,6 @@ import org.jooq.tools.jdbc.MockResult;
 import org.jooq.types.ULong;
 
 import java.sql.Connection;
-import java.sql.Date;
 import java.util.PriorityQueue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -78,7 +77,7 @@ public final class MockArchiveQueryProcessor implements ArchiveQuery {
     }
 
     @Override
-    public Result<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> processBetweenUnixEpochHours(
+    public Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> processBetweenUnixEpochHours(
             final long startHour,
             final long endHour
     ) {
@@ -90,11 +89,10 @@ public final class MockArchiveQueryProcessor implements ArchiveQuery {
             * you can also use ordinary jooq api to load csv files or
             * other formats, here! */
             final DSLContext create = DSL.using(SQLDialect.DEFAULT);
-            final Result<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> result = create
+            final Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> result = create
                     .newResult(
-                            SliceTable.id, SliceTable.directory, SliceTable.stream, SliceTable.host, SliceTable.logdate,
-                            SliceTable.bucket, SliceTable.path, SliceTable.logtime, SliceTable.filesize,
-                            SliceTable.uncompressedFilesize
+                            SliceTable.id, SliceTable.directory, SliceTable.stream, SliceTable.host, SliceTable.bucket,
+                            SliceTable.path, SliceTable.logtime, SliceTable.filesize, SliceTable.uncompressedFilesize
                     );
 
             while (!slice.isEmpty()) {
@@ -108,13 +106,13 @@ public final class MockArchiveQueryProcessor implements ArchiveQuery {
 
         final Connection connection = new MockConnection(provider);
         final DSLContext create = DSL.using(connection, SQLDialect.DEFAULT);
-        final Result<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> result;
+        final Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> result;
         try (
-                final SelectSelectStep<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> step = create
+                final SelectSelectStep<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> step = create
                         .select(
                                 SliceTable.id, SliceTable.directory, SliceTable.stream, SliceTable.host,
-                                SliceTable.logdate, SliceTable.bucket, SliceTable.path, SliceTable.logtime,
-                                SliceTable.filesize, SliceTable.uncompressedFilesize
+                                SliceTable.bucket, SliceTable.path, SliceTable.logtime, SliceTable.filesize,
+                                SliceTable.uncompressedFilesize
                         )
         ) {
             result = step.fetch();

--- a/src/test/java/com/teragrep/pth_06/planner/MockMeteredArchiveQueryProcessor.java
+++ b/src/test/java/com/teragrep/pth_06/planner/MockMeteredArchiveQueryProcessor.java
@@ -51,11 +51,9 @@ import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.SettableGauge;
 import com.teragrep.pth_06.metrics.TaskMetric;
 import org.apache.spark.sql.connector.metric.CustomTaskMetric;
-import org.jooq.Record10;
+import org.jooq.Record9;
 import org.jooq.Result;
 import org.jooq.types.ULong;
-
-import java.sql.Date;
 
 public final class MockMeteredArchiveQueryProcessor implements ArchiveQuery {
 
@@ -72,13 +70,13 @@ public final class MockMeteredArchiveQueryProcessor implements ArchiveQuery {
     }
 
     @Override
-    public Result<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> processBetweenUnixEpochHours(
+    public Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> processBetweenUnixEpochHours(
             long startHour,
             long endHour
     ) {
 
         final Timer.Context timerCtx = metricRegistry.timer("mockRowsTime").time();
-        final Result<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> rv;
+        final Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> rv;
         final long latencyNs;
 
         try {

--- a/src/test/java/com/teragrep/pth_06/planner/Recordable.java
+++ b/src/test/java/com/teragrep/pth_06/planner/Recordable.java
@@ -45,12 +45,10 @@
  */
 package com.teragrep.pth_06.planner;
 
-import org.jooq.Record10;
+import org.jooq.Record9;
 import org.jooq.types.ULong;
-
-import java.sql.Date;
 
 public interface Recordable {
 
-    Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong> asRecord();
+    Record9<ULong, String, String, String, String, String, Long, ULong, ULong> asRecord();
 }

--- a/src/test/java/com/teragrep/pth_06/planner/RecordableMockDBRow.java
+++ b/src/test/java/com/teragrep/pth_06/planner/RecordableMockDBRow.java
@@ -46,7 +46,7 @@
 package com.teragrep.pth_06.planner;
 
 import org.jooq.DSLContext;
-import org.jooq.Record10;
+import org.jooq.Record9;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
 import org.jooq.types.ULong;
@@ -128,19 +128,17 @@ public final class RecordableMockDBRow implements MockDBRow, Recordable {
     }
 
     @Override
-    public Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong> asRecord() {
-        final Record10<ULong, String, String, String, java.sql.Date, String, String, Long, ULong, ULong> newRecord = dslContext
+    public Record9<ULong, String, String, String, String, String, Long, ULong, ULong> asRecord() {
+        final Record9<ULong, String, String, String, String, String, Long, ULong, ULong> newRecord = dslContext
                 .newRecord(
-                        SliceTable.id, SliceTable.directory, SliceTable.stream, SliceTable.host, SliceTable.logdate,
-                        SliceTable.bucket, SliceTable.path, SliceTable.logtime, SliceTable.filesize,
-                        SliceTable.uncompressedFilesize
+                        SliceTable.id, SliceTable.directory, SliceTable.stream, SliceTable.host, SliceTable.bucket,
+                        SliceTable.path, SliceTable.logtime, SliceTable.filesize, SliceTable.uncompressedFilesize
                 );
 
         newRecord.set(SliceTable.id, ULong.valueOf(origin.id()));
         newRecord.set(SliceTable.directory, origin.directory());
         newRecord.set(SliceTable.stream, origin.stream());
         newRecord.set(SliceTable.host, origin.host());
-        newRecord.set(SliceTable.logdate, origin.logdate());
         newRecord.set(SliceTable.bucket, origin.bucket());
         newRecord.set(SliceTable.path, origin.path());
         newRecord.set(SliceTable.logtime, origin.logtime());

--- a/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
@@ -190,14 +190,11 @@ class StreamDBClientTest {
     public void pullToSliceTableSingleTest() {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
-        Instant instant = Instant.ofEpochSecond(1696471200L);
-        ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
-        ZonedDateTime instantPlusDay = instantZonedDateTime.plusDays(1);
-        // Set logdate to 2023-10-04 and set logtime-string in path to 2023100422 UTC-4, but set epoch values to null.
-        LogfileRecord logfileRecord = logfileRecordForEpoch(instantZonedDateTime.toEpochSecond(), true);
+        // Set logdate to 2023-10-05 and set logtime-string in path to 2023100502 UTC, but set epoch values to null.
+        LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
-        // Set logdate to 2023-10-05 and set logtime-string in path to 2023100522 UTC-4, but set epoch values to null.
-        LogfileRecord logfileRecord2 = logfileRecordForEpoch(instantPlusDay.toEpochSecond(), true);
+        // Set logdate to 2023-10-06 and set logtime-string in path to 2023100602 UTC, but set epoch values to null.
+        LogfileRecord logfileRecord2 = logfileRecordForEpoch(1696471200L + 24L * 3600L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
@@ -207,7 +204,7 @@ class StreamDBClientTest {
         Assertions.assertDoesNotThrow(() -> {
             try (final StreamDBClient sdc = new StreamDBClient(config)) {
                 // Only the row with logdate of "2023-10-4" should be pulled to slicetable.
-                int rows = sdc.pullToSliceTable(Date.valueOf(instantZonedDateTime.toLocalDate()));
+                int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
                 Assertions.assertEquals(1, rows);
             }
         });
@@ -220,14 +217,14 @@ class StreamDBClientTest {
     public void pullToSliceTableMultiTest() {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
-        // Set logdate to 2023-10-04 and set logtime-string in path to 2023100422 UTC-4, but set epoch values to null.
+        // Set logdate to 2023-10-04 and set logtime-string in path to 2023100502 UTC.
         Instant instant = Instant.ofEpochSecond(1696471200L);
         ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
         ZonedDateTime instantPlusHour = instantZonedDateTime.plusHours(1);
-        LogfileRecord logfileRecord = logfileRecordForEpoch(instantZonedDateTime.toEpochSecond(), true);
+        LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
-        // Set logdate to 2023-10-04 and set logtime-string in path to 2023100423 UTC-4, but set epoch values to null.
-        LogfileRecord logfileRecord2 = logfileRecordForEpoch(instantPlusHour.toEpochSecond(), true);
+        // Set logdate to 2023-10-04 and set logtime-string in path to 2023100503 UTC
+        LogfileRecord logfileRecord2 = logfileRecordForEpoch(1696471200L + 3600L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
@@ -236,8 +233,8 @@ class StreamDBClientTest {
         final Config config = new Config(opts);
         Assertions.assertDoesNotThrow(() -> {
             try (final StreamDBClient sdc = new StreamDBClient(config)) {
-                // Both of the rows in the database for logdate of "2023-10-4" should be pulled to the slicetable.
-                int rows = sdc.pullToSliceTable(Date.valueOf(instantZonedDateTime.toLocalDate()));
+                // Both of the rows in the database for logdate of "2023-10-5" should be pulled to the slicetable.
+                int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
                 Assertions.assertEquals(2, rows);
             }
         });

--- a/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
@@ -200,7 +200,7 @@ class StreamDBClientTest {
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
-        final Map<String, String> opts = this.opts;
+        final Map<String, String> opts = new HashMap<>(this.opts);
         opts.put("DBurl", mariadb.getJdbcUrl());
         final Config config = new Config(opts);
         Assertions.assertDoesNotThrow(() -> {
@@ -230,7 +230,7 @@ class StreamDBClientTest {
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
-        final Map<String, String> opts = this.opts;
+        final Map<String, String> opts = new HashMap<>(this.opts);
         opts.put("DBurl", mariadb.getJdbcUrl());
         final Config config = new Config(opts);
         Assertions.assertDoesNotThrow(() -> {
@@ -282,7 +282,7 @@ class StreamDBClientTest {
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
-        final Map<String, String> opts = this.opts;
+        final Map<String, String> opts = new HashMap<>(this.opts);
         opts.put("DBurl", mariadb.getJdbcUrl());
         final Config config = new Config(opts);
         final StreamDBClient sdc = Assertions.assertDoesNotThrow(() -> new StreamDBClient(config));
@@ -322,7 +322,7 @@ class StreamDBClientTest {
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
-        final Map<String, String> opts = this.opts;
+        final Map<String, String> opts = new HashMap<>(this.opts);
         opts.put("DBurl", mariadb.getJdbcUrl());
         final Config config = new Config(opts);
         Assertions.assertDoesNotThrow(() -> {
@@ -367,7 +367,7 @@ class StreamDBClientTest {
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
-        final Map<String, String> opts = this.opts;
+        final Map<String, String> opts = new HashMap<>(this.opts);
         opts.put("DBurl", mariadb.getJdbcUrl());
         final Config config = new Config(opts);
         final StreamDBClient sdc = Assertions.assertDoesNotThrow(() -> new StreamDBClient(config));
@@ -394,7 +394,7 @@ class StreamDBClientTest {
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
-        final Map<String, String> opts = this.opts;
+        final Map<String, String> opts = new HashMap<>(this.opts);
         opts.put("DBurl", mariadb.getJdbcUrl());
         final Config config = new Config(opts);
         Assertions.assertDoesNotThrow(() -> {
@@ -429,7 +429,7 @@ class StreamDBClientTest {
         ctx.insertInto(JOURNALDB.LOGFILE).set(plusOneDayRecord).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
-        final Map<String, String> opts = this.opts;
+        final Map<String, String> opts = new HashMap<>(this.opts);
         opts.put("DBurl", mariadb.getJdbcUrl());
 
         final Config config = new Config(opts);
@@ -472,7 +472,7 @@ class StreamDBClientTest {
         ctx.insertInto(JOURNALDB.LOGFILE).set(plusOneDayRecord).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
-        final Map<String, String> opts = this.opts;
+        final Map<String, String> opts = new HashMap<>(this.opts);
         opts.put("DBurl", mariadb.getJdbcUrl());
 
         final Config config = new Config(opts);
@@ -580,7 +580,7 @@ class StreamDBClientTest {
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
-        final Map<String, String> opts = this.opts;
+        final Map<String, String> opts = new HashMap<>(this.opts);
         opts.put("DBurl", mariadb.getJdbcUrl());
         final Config config = new Config(opts);
         final StreamDBClient sdc = Assertions.assertDoesNotThrow(() -> new StreamDBClient(config));
@@ -610,7 +610,7 @@ class StreamDBClientTest {
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
-        final Map<String, String> opts = this.opts;
+        final Map<String, String> opts = new HashMap<>(this.opts);
         opts.put("DBurl", mariadb.getJdbcUrl());
         final Config config = new Config(opts);
         Assertions.assertDoesNotThrow(() -> {
@@ -648,7 +648,7 @@ class StreamDBClientTest {
         // Assert StreamDBClient methods work as expected with the test data.
 
         // Set includeBeforeEpoch in ArchiveConfig to an epoch that represents 2023-10-05 03:00 UTC, for getNextHourAndSizeFromSliceTable() to ignore records with logtime of 2023-10-05 03:00 UTC or newer.
-        final Map<String, String> opts = this.opts;
+        final Map<String, String> opts = new HashMap<>(this.opts);
         opts.put("DBurl", mariadb.getJdbcUrl());
         opts.put("archive.includeBeforeEpoch", String.valueOf(instantPlusHour.getEpochSecond()));
         final Config config = new Config(opts);
@@ -688,7 +688,7 @@ class StreamDBClientTest {
         // Assert StreamDBClient methods work as expected with the test data.
 
         // Set includeBeforeEpoch in ArchiveConfig to an epoch that represents 2023-10-04 23:00 UTC-4, for getNextHourAndSizeFromSliceTable() to ignore records with logtime of 2023-10-04 23:00 UTC-4 or newer.
-        final Map<String, String> opts = this.opts;
+        final Map<String, String> opts = new HashMap<>(this.opts);
         opts.put("DBurl", mariadb.getJdbcUrl());
         opts.put("archive.includeBeforeEpoch", String.valueOf(instantPlusHour.toEpochSecond()));
         final Config config = new Config(opts);
@@ -818,7 +818,7 @@ class StreamDBClientTest {
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
 
         // Create an instance of StreamDBClient using the default server timezone (UTC-4).
-        final Map<String, String> opts = this.opts;
+        final Map<String, String> opts = new HashMap<>(this.opts);
         opts.put("DBurl", mariadb.getJdbcUrl());
         final Config config = new Config(opts);
         final StreamDBClient sdc = Assertions.assertDoesNotThrow(() -> new StreamDBClient(config));

--- a/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
@@ -114,6 +114,7 @@ class StreamDBClientTest {
 
     @AfterEach
     public void cleanup() {
+        Assertions.assertDoesNotThrow(() -> connection.close());
         mariadb.stop();
     }
 

--- a/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
@@ -669,40 +669,62 @@ class StreamDBClientTest {
     }
 
     /**
-     * Testing timezone handling of epoch_hour and logtime near midnight.
+     * Testing timezone handling of epoch_hour and logtime near midnight using 2 different session timezones.
      */
     @Test
     public void epochHourTimezoneTest() {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
-        // Set epoch_hour to 2023-10-05 01:00 UTC, which will cause issues if session timezone (America/New_York, UTC-4) is affecting logtime and logdate result.
+        // Create a LogfileRecord object with epoch_hour of 2023-10-05 01:00 UTC.
         LogfileRecord logfileRecord = logfileRecordForEpoch(1696467600L, false);
+        // Insert the logfileRecord to the database using JOOQ.
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
 
-        // Assert StreamDBClient methods work as expected with the test data.
+        // Create an instance of StreamDBClient using the default server timezone (UTC-4).
         final Map<String, String> opts = this.opts;
         opts.put("DBurl", mariadb.getJdbcUrl());
         final Config config = new Config(opts);
         final StreamDBClient sdc = Assertions.assertDoesNotThrow(() -> new StreamDBClient(config));
-        Long earliestEpoch = 1696377600L; // 2023-10-04
+        // Create another instance of StreamDBClient using explicitly set UTC session timezone.
+        final Map<String, String> optsUTC = this.opts;
+        optsUTC.put("DBurl", mariadb.getJdbcUrl() + "?forceConnectionTimeZoneToSession=true&connectionTimeZone=UTC");
+        final Config configUTC = new Config(optsUTC);
+        final StreamDBClient sdcUTC = Assertions.assertDoesNotThrow(() -> new StreamDBClient(configUTC));
+
+        final Long earliestEpoch = 1696377600L; // 2023-10-04
         Long latestOffset = earliestEpoch;
 
         // Pull the records from a specific logdate to the slicetable for further processing.
         int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
         Assertions.assertEquals(1, rows);
+        // Do the same for sdcUTC
+        Assertions.assertEquals(rows, sdcUTC.pullToSliceTable(Date.valueOf("2023-10-5")));
 
         // Get the offset for the first non-empty hour of records from the slicetable.
         WeightedOffset nextHourAndSizeFromSliceTable = sdc.getNextHourAndSizeFromSliceTable(latestOffset);
         Assertions.assertFalse(nextHourAndSizeFromSliceTable.isStub);
+        // Do the same for sdcUTC
+        WeightedOffset nextHourAndSizeFromSliceTableUTC = sdcUTC.getNextHourAndSizeFromSliceTable(latestOffset);
+        Assertions.assertFalse(nextHourAndSizeFromSliceTableUTC.isStub);
+
         latestOffset = nextHourAndSizeFromSliceTable.offset();
+        Assertions.assertEquals(latestOffset, nextHourAndSizeFromSliceTableUTC.offset());
+
+        // Get the logfile results from the known hour range.
         Assertions.assertEquals(1696467600L, latestOffset);
         Result<Record11<ULong, String, String, String, String, Date, String, String, Long, ULong, ULong>> hourRange = sdc
                 .getHourRange(earliestEpoch, latestOffset);
         Assertions.assertEquals(1, hourRange.size());
+        // Do the same for sdcUTC
+        Result<Record11<ULong, String, String, String, String, Date, String, String, Long, ULong, ULong>> hourRangeUTC = sdcUTC
+                .getHourRange(earliestEpoch, latestOffset);
+        Assertions.assertEquals(1, hourRangeUTC.size());
         // Assert that the resulting logfile metadata is as expected for logdate and logtime, they should not be affected by session timezone.
         ZonedDateTime zonedDateTimeUTC = ZonedDateTime.of(2023, 10, 5, 1, 0, 0, 0, ZoneId.of("UTC"));
         Assertions.assertEquals(zonedDateTimeUTC.toEpochSecond(), hourRange.get(0).get(8, Long.class));
+        Assertions.assertEquals(zonedDateTimeUTC.toEpochSecond(), hourRangeUTC.get(0).get(8, Long.class));
         Assertions.assertEquals(Date.valueOf("2023-10-5"), hourRange.get(0).get(5, Date.class));
+        Assertions.assertEquals(Date.valueOf("2023-10-5"), hourRangeUTC.get(0).get(5, Date.class));
     }
 
     @Test

--- a/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
@@ -192,10 +192,10 @@ class StreamDBClientTest {
     public void pullToSliceTableSingleTest() {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
-        // Set logdate to 2023-10-05 and set logtime-string in path to 2023100502 UTC, but set epoch values to null.
+        // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
         LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
-        // Set logdate to 2023-10-06 and set logtime-string in path to 2023100602 UTC, but set epoch values to null.
+        // Set logdate and logtime to 2023-10-05:22 UTC-4 and set epoch_hour in path to 2023-10-06:02 UTC.
         LogfileRecord logfileRecord2 = logfileRecordForEpoch(1696471200L + 24L * 3600L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
 
@@ -205,7 +205,7 @@ class StreamDBClientTest {
         final Config config = new Config(opts);
         Assertions.assertDoesNotThrow(() -> {
             try (final StreamDBClient sdc = new StreamDBClient(config)) {
-                // Only the row with logdate of "2023-10-4" should be pulled to slicetable.
+                // Only the row with epoch_hour referring to 2023-10-5 should be pulled to slicetable.
                 int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
                 Assertions.assertEquals(1, rows);
             }
@@ -219,10 +219,10 @@ class StreamDBClientTest {
     public void pullToSliceTableMultiTest() {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
-        // Set logdate to 2023-10-04 and set logtime-string in path to 2023100502 UTC.
+        // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
         LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
-        // Set logdate to 2023-10-04 and set logtime-string in path to 2023100503 UTC
+        // Set logdate and logtime to 2023-10-04:23 UTC-4 and set epoch_hour in path to 2023-10-05:03 UTC.
         LogfileRecord logfileRecord2 = logfileRecordForEpoch(1696471200L + 3600L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
 
@@ -232,7 +232,7 @@ class StreamDBClientTest {
         final Config config = new Config(opts);
         Assertions.assertDoesNotThrow(() -> {
             try (final StreamDBClient sdc = new StreamDBClient(config)) {
-                // Both of the rows in the database for logdate of "2023-10-5" should be pulled to the slicetable.
+                // Both of the rows in the database with epoch_hour referring to "2023-10-5" should be pulled to the slicetable.
                 int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
                 Assertions.assertEquals(2, rows);
             }
@@ -247,7 +247,7 @@ class StreamDBClientTest {
     public void pullToSliceTableInvalidIndexTest() {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
-        // Set logdate to 2023-10-04 and set logtime-string in path to 2023100502 UTC.
+        // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
         LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
 
@@ -272,7 +272,7 @@ class StreamDBClientTest {
     public void epochHourTest() {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
-        // Set logdate and logtime to 2023-10-04 instead of the correct 2023-10-05 which epoch_hour is at, to test if epoch_hour takes priority or not.
+        // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
         LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
 
@@ -353,11 +353,11 @@ class StreamDBClientTest {
     public void getNextHourAndSizeFromSliceTableEpochTest() {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
-        // Set logdate to 2023-10-04 and set logtime-string in path to 2023100422 UTC.
+        // Set logdate and logtime to 2023-10-04:18 UTC-4 and set epoch_hour in path to 2023-10-04:22 UTC.
         Instant instant = Instant.ofEpochSecond(1696456800L);
         LogfileRecord logfileRecord = logfileRecordForEpoch(1696456800L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
-        // Set logdate to 2023-10-04 and set logtime-string in path to 2023100423 UTC.
+        // Set logdate and logtime to 2023-10-04:19 UTC-4 and set epoch_hour in path to 2023-10-04:23 UTC.
         LogfileRecord logfileRecord2 = logfileRecordForEpoch(1696456800L + 3600L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
 
@@ -632,7 +632,7 @@ class StreamDBClientTest {
 
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
-        // Inserting logfile with logtime of 2023-10-05 02:00 UTC.
+        // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
         Instant instant = Instant.ofEpochSecond(1696471200);
         Instant instantPlusHour = instant.plusSeconds(3600);
         LogfileRecord logfileRecord = logfileRecordForEpoch(instant.getEpochSecond(), false);
@@ -671,7 +671,7 @@ class StreamDBClientTest {
 
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
-        // Inserting logfile with logtime of 2023-10-04 22:00 UTC-4.
+        // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
         Instant instant = Instant.ofEpochSecond(1696471200L);
         ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
         ZonedDateTime instantPlusHour = instantZonedDateTime.plusHours(1);
@@ -712,7 +712,7 @@ class StreamDBClientTest {
     public void logtagIdTest() {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
-        // Inserting logfile with logtime of 2023-10-05 02:00 UTC.
+        // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
         Instant instant = Instant.ofEpochSecond(1696471200L);
         LogfileRecord logfileRecord = logfileRecordForEpoch(instant.getEpochSecond(), false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
@@ -752,7 +752,7 @@ class StreamDBClientTest {
     public void logtagTest() {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
-        // Inserting logfile with logtime of 2023-10-05 02:00 UTC.
+        // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
         Instant instant = Instant.ofEpochSecond(1696471200L);
         LogfileRecord logfileRecord = logfileRecordForEpoch(instant.getEpochSecond(), false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
@@ -777,7 +777,7 @@ class StreamDBClientTest {
     public void pullToSliceTableSkipsCorruptedLogfilesTest() {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
-        // Inserting logfile with logtime of 2023-10-05 02:00 UTC.
+        // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
         Instant instant = Instant.ofEpochSecond(1696471200L);
         LogfileRecord corruptedLogfileRecord = logfileRecordForEpoch(instant.getEpochSecond(), false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(corruptedLogfileRecord).execute();
@@ -804,7 +804,7 @@ class StreamDBClientTest {
     public void epochHourTimezoneTest() {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
-        // Create a LogfileRecord object with epoch_hour of 2023-10-05 01:00 UTC.
+        // Set logdate and logtime to 2023-10-04:21 UTC-4 and set epoch_hour in path to 2023-10-05:01 UTC.
         LogfileRecord logfileRecord = logfileRecordForEpoch(1696467600L, false);
         // Insert the logfileRecord to the database using JOOQ.
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();

--- a/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
@@ -61,8 +61,13 @@ import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
-import java.sql.*;
-import java.time.*;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.DriverManager;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
@@ -266,6 +266,42 @@ class StreamDBClientTest {
     }
 
     /**
+     * Testing situation where epoch_hour is used as a source for logtime and logdate fields.
+     */
+    @Test
+    public void epochHourTest() {
+        // Add test data to logfile table in journaldb.
+        final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
+        // Set logdate and logtime to 2023-10-04 instead of the correct 2023-10-05 which epoch_hour is at, to test if epoch_hour takes priority or not.
+        LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
+
+        // Assert StreamDBClient methods work as expected with the test data.
+        final Map<String, String> opts = this.opts;
+        opts.put("DBurl", mariadb.getJdbcUrl());
+        final Config config = new Config(opts);
+        final StreamDBClient sdc = Assertions.assertDoesNotThrow(() -> new StreamDBClient(config));
+        Long earliestEpoch = 1696377600L; // 2023-10-04
+        Long latestOffset = earliestEpoch;
+
+        // Pull the records from a specific logdate to the slicetable for further processing.
+        int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
+        Assertions.assertEquals(1, rows);
+
+        // Get the offset for the first non-empty hour of records from the slicetable.
+        WeightedOffset nextHourAndSizeFromSliceTable = sdc.getNextHourAndSizeFromSliceTable(latestOffset);
+        Assertions.assertFalse(nextHourAndSizeFromSliceTable.isStub);
+        latestOffset = nextHourAndSizeFromSliceTable.offset();
+        Assertions.assertEquals(1696471200L, latestOffset);
+        Result<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> hourRange = sdc
+                .getHourRange(earliestEpoch, latestOffset);
+        Assertions.assertEquals(1, hourRange.size());
+        // Assert that the resulting logfile metadata is as expected for logdate and logtime.
+        Assertions.assertEquals(1696471200L, hourRange.get(0).get(7, Long.class));
+        Assertions.assertEquals(Date.valueOf("2023-10-5"), hourRange.get(0).get(4, Date.class));
+    }
+
+    /**
      * Testing situation where logfile record hasn't been migrated to use epoch columns. Will use old logdate and
      * synthetic logtime fields instead as a fallback which will trigger the session timezone to affect logtime results.
      */

--- a/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
@@ -293,12 +293,11 @@ class StreamDBClientTest {
         Assertions.assertFalse(nextHourAndSizeFromSliceTable.isStub);
         latestOffset = nextHourAndSizeFromSliceTable.offset();
         Assertions.assertEquals(1696471200L, latestOffset);
-        Result<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> hourRange = sdc
+        Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> hourRange = sdc
                 .getHourRange(earliestEpoch, latestOffset);
         Assertions.assertEquals(1, hourRange.size());
-        // Assert that the resulting logfile metadata is as expected for logdate and logtime.
-        Assertions.assertEquals(1696471200L, hourRange.get(0).get(7, Long.class));
-        Assertions.assertEquals(Date.valueOf("2023-10-5"), hourRange.get(0).get(4, Date.class));
+        // Assert that the resulting logfile metadata is as expected for logtime.
+        Assertions.assertEquals(1696471200L, hourRange.get(0).get(6, Long.class));
     }
 
     /**
@@ -336,7 +335,7 @@ class StreamDBClientTest {
                 long latestOffset = nextHourAndSizeFromSliceTable.offset();
                 // zonedDateTime is used for checking timestamp errors caused by synthetic creation of logtime from logfile path column using regex.
                 Assertions.assertEquals(instantZonedDateTime.toEpochSecond(), latestOffset);
-                Result<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> hourRange = sdc
+                Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> hourRange = sdc
                         .getHourRange(earliestEpoch, latestOffset);
                 Assertions.assertEquals(1, hourRange.size());
                 // Assert that resulting logfile metadata for logtime is affected by the session timezone when epoch columns are null and session timezone is America/New_York.
@@ -738,7 +737,7 @@ class StreamDBClientTest {
                 Assertions.assertFalse(nextHourAndSizeFromSliceTable.isStub);
                 final long latestOffset = nextHourAndSizeFromSliceTable.offset();
                 // Get the record from slicetable and assert that it was found with the queryXML condition.
-                Result<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> hourRange = sdc
+                Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> hourRange = sdc
                         .getHourRange(earliestEpoch, latestOffset);
                 Assertions.assertEquals(1, hourRange.size());
             }
@@ -841,19 +840,17 @@ class StreamDBClientTest {
 
         // Get the logfile results from the known hour range.
         Assertions.assertEquals(1696467600L, latestOffset);
-        Result<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> hourRange = sdc
+        Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> hourRange = sdc
                 .getHourRange(earliestEpoch, latestOffset);
         Assertions.assertEquals(1, hourRange.size());
         // Do the same for sdcUTC
-        Result<Record10<ULong, String, String, String, Date, String, String, Long, ULong, ULong>> hourRangeUTC = sdcUTC
+        Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> hourRangeUTC = sdcUTC
                 .getHourRange(earliestEpoch, latestOffset);
         Assertions.assertEquals(1, hourRangeUTC.size());
-        // Assert that the resulting logfile metadata is as expected for logdate and logtime, they should not be affected by session timezone.
+        // Assert that the resulting logfile metadata is as expected for logtime, they should not be affected by session timezone.
         ZonedDateTime zonedDateTimeUTC = ZonedDateTime.of(2023, 10, 5, 1, 0, 0, 0, ZoneId.of("UTC"));
-        Assertions.assertEquals(zonedDateTimeUTC.toEpochSecond(), hourRange.get(0).get(7, Long.class));
-        Assertions.assertEquals(zonedDateTimeUTC.toEpochSecond(), hourRangeUTC.get(0).get(7, Long.class));
-        Assertions.assertEquals(Date.valueOf("2023-10-5"), hourRange.get(0).get(4, Date.class));
-        Assertions.assertEquals(Date.valueOf("2023-10-5"), hourRangeUTC.get(0).get(4, Date.class));
+        Assertions.assertEquals(zonedDateTimeUTC.toEpochSecond(), hourRange.get(0).get(6, Long.class));
+        Assertions.assertEquals(zonedDateTimeUTC.toEpochSecond(), hourRangeUTC.get(0).get(6, Long.class));
     }
 
     @Test

--- a/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
@@ -121,17 +121,17 @@ class StreamDBClientTest {
     }
 
     private LogfileRecord logfileRecordForEpoch(long epoch, boolean hasNullEpochColumns) {
-        Instant instant = Instant.ofEpochSecond(epoch);
-        ZonedDateTime zonedDateTime = instant.atZone(zoneId); // expects path dates to be in same timezone as mariadb system timezone
-        int year = zonedDateTime.getYear();
+        final Instant instant = Instant.ofEpochSecond(epoch);
+        final ZonedDateTime zonedDateTime = instant.atZone(zoneId); // expects path dates to be in same timezone as mariadb system timezone
+        final int year = zonedDateTime.getYear();
         // format 0 in front of string if 1-9
-        String month = String.format("%02d", zonedDateTime.getMonthValue());
-        String day = String.format("%02d", zonedDateTime.getDayOfMonth());
-        String hour = String.format("%02d", zonedDateTime.getHour());
+        final String month = String.format("%02d", zonedDateTime.getMonthValue());
+        final String day = String.format("%02d", zonedDateTime.getDayOfMonth());
+        final String hour = String.format("%02d", zonedDateTime.getHour());
 
-        String filename = "example.log-@" + epoch + "-" + year + month + day + hour + ".log.gz";
-        String path = year + "/" + month + "-" + day + "/example.tg.dev.test/example/" + filename;
-        LogfileRecord logfileRecord = new LogfileRecord(
+        final String filename = "example.log-@" + epoch + "-" + year + month + day + hour + ".log.gz";
+        final String path = year + "/" + month + "-" + day + "/example.tg.dev.test/example/" + filename;
+        final LogfileRecord logfileRecord = new LogfileRecord(
                 ULong.valueOf(ThreadLocalRandom.current().nextLong(0L, Long.MAX_VALUE)),
                 Date.valueOf(zonedDateTime.toLocalDate()),
                 Date.valueOf(zonedDateTime.plusYears(1).toLocalDate()),
@@ -155,7 +155,7 @@ class StreamDBClientTest {
                 null
         );
 
-        LogfileRecord nullEpochRecord = new LogfileRecord(
+        final LogfileRecord nullEpochRecord = new LogfileRecord(
                 ULong.valueOf(ThreadLocalRandom.current().nextLong(0L, Long.MAX_VALUE)),
                 Date.valueOf(zonedDateTime.toLocalDate()),
                 Date.valueOf(zonedDateTime.plusYears(1).toLocalDate()),
@@ -193,10 +193,10 @@ class StreamDBClientTest {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
         // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
-        LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
         // Set logdate and logtime to 2023-10-05:22 UTC-4 and set epoch_hour in path to 2023-10-06:02 UTC.
-        LogfileRecord logfileRecord2 = logfileRecordForEpoch(1696471200L + 24L * 3600L, false);
+        final LogfileRecord logfileRecord2 = logfileRecordForEpoch(1696471200L + 24L * 3600L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
@@ -206,7 +206,7 @@ class StreamDBClientTest {
         Assertions.assertDoesNotThrow(() -> {
             try (final StreamDBClient sdc = new StreamDBClient(config)) {
                 // Only the row with epoch_hour referring to 2023-10-5 should be pulled to slicetable.
-                int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
+                final int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
                 Assertions.assertEquals(1, rows);
             }
         });
@@ -220,10 +220,10 @@ class StreamDBClientTest {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
         // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
-        LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
         // Set logdate and logtime to 2023-10-04:23 UTC-4 and set epoch_hour in path to 2023-10-05:03 UTC.
-        LogfileRecord logfileRecord2 = logfileRecordForEpoch(1696471200L + 3600L, false);
+        final LogfileRecord logfileRecord2 = logfileRecordForEpoch(1696471200L + 3600L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
@@ -233,7 +233,7 @@ class StreamDBClientTest {
         Assertions.assertDoesNotThrow(() -> {
             try (final StreamDBClient sdc = new StreamDBClient(config)) {
                 // Both of the rows in the database with epoch_hour referring to "2023-10-5" should be pulled to the slicetable.
-                int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
+                final int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
                 Assertions.assertEquals(2, rows);
             }
         });
@@ -248,7 +248,7 @@ class StreamDBClientTest {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
         // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
-        LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
@@ -259,7 +259,7 @@ class StreamDBClientTest {
         Assertions.assertDoesNotThrow(() -> {
             try (final StreamDBClient sdc = new StreamDBClient(config)) {
                 // 0 rows should be pulled to sliceTable
-                int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
+                final int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
                 Assertions.assertEquals(0, rows);
             }
         });
@@ -273,7 +273,7 @@ class StreamDBClientTest {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
         // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
-        LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
@@ -281,19 +281,18 @@ class StreamDBClientTest {
         opts.put("DBurl", mariadb.getJdbcUrl());
         final Config config = new Config(opts);
         final StreamDBClient sdc = Assertions.assertDoesNotThrow(() -> new StreamDBClient(config));
-        Long earliestEpoch = 1696377600L; // 2023-10-04
-        Long latestOffset = earliestEpoch;
+        final Long earliestEpoch = 1696377600L; // 2023-10-04
 
         // Pull the records from a specific logdate to the slicetable for further processing.
         int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
         Assertions.assertEquals(1, rows);
 
         // Get the offset for the first non-empty hour of records from the slicetable.
-        WeightedOffset nextHourAndSizeFromSliceTable = sdc.getNextHourAndSizeFromSliceTable(latestOffset);
+        final WeightedOffset nextHourAndSizeFromSliceTable = sdc.getNextHourAndSizeFromSliceTable(earliestEpoch);
         Assertions.assertFalse(nextHourAndSizeFromSliceTable.isStub);
-        latestOffset = nextHourAndSizeFromSliceTable.offset();
+        final Long latestOffset = nextHourAndSizeFromSliceTable.offset();
         Assertions.assertEquals(1696471200L, latestOffset);
-        Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> hourRange = sdc
+        final Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> hourRange = sdc
                 .getHourRange(earliestEpoch, latestOffset);
         Assertions.assertEquals(1, hourRange.size());
         // Assert that the resulting logfile metadata is as expected for logtime.
@@ -310,9 +309,9 @@ class StreamDBClientTest {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
         // Set logdate to 2023-10-04 and set logtime-string in path to 2023100422 UTC-4, but set epoch values to null.
-        Instant instant = Instant.ofEpochSecond(1696471200L);
-        ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
-        LogfileRecord logfileRecord = logfileRecordForEpoch(instantZonedDateTime.toEpochSecond(), true);
+        final Instant instant = Instant.ofEpochSecond(1696471200L);
+        final ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(instantZonedDateTime.toEpochSecond(), true);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
@@ -321,25 +320,25 @@ class StreamDBClientTest {
         final Config config = new Config(opts);
         Assertions.assertDoesNotThrow(() -> {
             try (final StreamDBClient sdc = new StreamDBClient(config)) {
-                Instant instantEarliest = Instant.ofEpochSecond(1696392000L);
-                ZonedDateTime instantEarliestZonedDateTime = ZonedDateTime.ofInstant(instantEarliest, zoneId);
-                long earliestEpoch = instantEarliestZonedDateTime.toEpochSecond(); // 2023-10-04 00:00 UTC-4
+                final Instant instantEarliest = Instant.ofEpochSecond(1696392000L);
+                final ZonedDateTime instantEarliestZonedDateTime = ZonedDateTime.ofInstant(instantEarliest, zoneId);
+                final long earliestEpoch = instantEarliestZonedDateTime.toEpochSecond(); // 2023-10-04 00:00 UTC-4
 
                 // Pull the records from a specific logdate to the slicetable for further processing.
-                int rows = sdc.pullToSliceTable(Date.valueOf(instantEarliestZonedDateTime.toLocalDate()));
+                final int rows = sdc.pullToSliceTable(Date.valueOf(instantEarliestZonedDateTime.toLocalDate()));
                 Assertions.assertEquals(1, rows);
 
                 // Get the offset for the first non-empty hour of records from the slicetable.
-                WeightedOffset nextHourAndSizeFromSliceTable = sdc.getNextHourAndSizeFromSliceTable(0L);
+                final WeightedOffset nextHourAndSizeFromSliceTable = sdc.getNextHourAndSizeFromSliceTable(0L);
                 Assertions.assertFalse(nextHourAndSizeFromSliceTable.isStub);
-                long latestOffset = nextHourAndSizeFromSliceTable.offset();
+                final long latestOffset = nextHourAndSizeFromSliceTable.offset();
                 // zonedDateTime is used for checking timestamp errors caused by synthetic creation of logtime from logfile path column using regex.
                 Assertions.assertEquals(instantZonedDateTime.toEpochSecond(), latestOffset);
-                Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> hourRange = sdc
+                final Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> hourRange = sdc
                         .getHourRange(earliestEpoch, latestOffset);
                 Assertions.assertEquals(1, hourRange.size());
                 // Assert that resulting logfile metadata for logtime is affected by the session timezone when epoch columns are null and session timezone is America/New_York.
-                long logtime = hourRange.get(0).get(7, Long.class);
+                final long logtime = hourRange.get(0).get(7, Long.class);
                 Assertions.assertEquals(instantZonedDateTime.toEpochSecond(), logtime);
                 // Assert that the resulting logfile metadata is as expected for logdate.
                 Assertions
@@ -353,11 +352,10 @@ class StreamDBClientTest {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
         // Set logdate and logtime to 2023-10-04:18 UTC-4 and set epoch_hour in path to 2023-10-04:22 UTC.
-        Instant instant = Instant.ofEpochSecond(1696456800L);
-        LogfileRecord logfileRecord = logfileRecordForEpoch(1696456800L, false);
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(1696456800L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
         // Set logdate and logtime to 2023-10-04:19 UTC-4 and set epoch_hour in path to 2023-10-04:23 UTC.
-        LogfileRecord logfileRecord2 = logfileRecordForEpoch(1696456800L + 3600L, false);
+        final LogfileRecord logfileRecord2 = logfileRecordForEpoch(1696456800L + 3600L, false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
@@ -365,9 +363,9 @@ class StreamDBClientTest {
         opts.put("DBurl", mariadb.getJdbcUrl());
         final Config config = new Config(opts);
         final StreamDBClient sdc = Assertions.assertDoesNotThrow(() -> new StreamDBClient(config));
-        int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-4"));
+        final int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-4"));
         Assertions.assertEquals(2, rows);
-        WeightedOffset nextHourAndSizeFromSliceTable = sdc.getNextHourAndSizeFromSliceTable(1696456800L);
+        final WeightedOffset nextHourAndSizeFromSliceTable = sdc.getNextHourAndSizeFromSliceTable(1696456800L);
         // Assert that the result for next hour from slice table after 2023-10-4 22:00 UTC is 2023-10-4 23:00 UTC.
         Assertions.assertEquals(1696456800L + 3600L, nextHourAndSizeFromSliceTable.offset());
     }
@@ -378,13 +376,13 @@ class StreamDBClientTest {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
         // Set logdate to 2023-10-04 and set logtime-string in path to 2023100422 UTC-4, but set epoch values to null.
-        Instant instant = Instant.ofEpochSecond(1696471200L);
-        ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
-        ZonedDateTime instantPlusHour = instantZonedDateTime.plusHours(1);
-        LogfileRecord logfileRecord = logfileRecordForEpoch(instantZonedDateTime.toEpochSecond(), true);
+        final Instant instant = Instant.ofEpochSecond(1696471200L);
+        final ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
+        final ZonedDateTime instantPlusHour = instantZonedDateTime.plusHours(1);
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(instantZonedDateTime.toEpochSecond(), true);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
         // Set logdate to 2023-10-04 and set logtime-string in path to 2023100423 UTC-4, but set epoch values to null.
-        LogfileRecord logfileRecord2 = logfileRecordForEpoch(instantPlusHour.toEpochSecond(), true);
+        final LogfileRecord logfileRecord2 = logfileRecordForEpoch(instantPlusHour.toEpochSecond(), true);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
@@ -393,9 +391,9 @@ class StreamDBClientTest {
         final Config config = new Config(opts);
         Assertions.assertDoesNotThrow(() -> {
             try (final StreamDBClient sdc = new StreamDBClient(config)) {
-                int rows = sdc.pullToSliceTable(Date.valueOf(instantZonedDateTime.toLocalDate()));
+                final int rows = sdc.pullToSliceTable(Date.valueOf(instantZonedDateTime.toLocalDate()));
                 Assertions.assertEquals(2, rows);
-                WeightedOffset nextHourAndSizeFromSliceTable = sdc
+                final WeightedOffset nextHourAndSizeFromSliceTable = sdc
                         .getNextHourAndSizeFromSliceTable(instantZonedDateTime.toEpochSecond());
                 // Assert that the result for next hour from slice table after 2023-10-4 22:00 UTC-4 is 2023-10-4 23:00 UTC-4.
                 Assertions.assertEquals(instantPlusHour.toEpochSecond(), nextHourAndSizeFromSliceTable.offset());
@@ -552,7 +550,7 @@ class StreamDBClientTest {
         localOpts.put("DBurl", mariadb.getJdbcUrl());
         final Config config = new Config(localOpts);
         final StreamDBClient sdc = Assertions.assertDoesNotThrow(() -> new StreamDBClient(config));
-        int pulled = sdc.pullToSliceTable(Date.valueOf(recordZdt.toLocalDate()));
+        final int pulled = sdc.pullToSliceTable(Date.valueOf(recordZdt.toLocalDate()));
         final ZonedDateTime baseTime = ZonedDateTime.of(2023, 10, 4, 22, 0, 0, 0, ZoneId.of("UTC"));
         Assertions.assertEquals(1, pulled, "row should be pulled to slice table");
         final int deleted = sdc
@@ -570,8 +568,8 @@ class StreamDBClientTest {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
         // Inserting logfile with logtime of 2023-10-05 02:00 UTC.
-        Instant instant = Instant.ofEpochSecond(1696471200L);
-        LogfileRecord logfileRecord = logfileRecordForEpoch(instant.getEpochSecond(), false);
+        final Instant instant = Instant.ofEpochSecond(1696471200L);
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(instant.getEpochSecond(), false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
@@ -581,7 +579,7 @@ class StreamDBClientTest {
         final StreamDBClient sdc = Assertions.assertDoesNotThrow(() -> new StreamDBClient(config));
 
         // Pull the records from a specific logdate to the slicetable for further processing.
-        int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
+        final int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
         Assertions.assertEquals(1, rows);
         Assertions.assertFalse(sdc.getNextHourAndSizeFromSliceTable(0L).isStub);
 
@@ -599,9 +597,9 @@ class StreamDBClientTest {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
         // Inserting logfile with logtime of 2023-10-04 22:00 UTC-4.
-        Instant instant = Instant.ofEpochSecond(1696471200L);
-        ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
-        LogfileRecord logfileRecord = logfileRecordForEpoch(instantZonedDateTime.toEpochSecond(), true);
+        final Instant instant = Instant.ofEpochSecond(1696471200L);
+        final ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(instantZonedDateTime.toEpochSecond(), true);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
@@ -611,7 +609,7 @@ class StreamDBClientTest {
         Assertions.assertDoesNotThrow(() -> {
             try (final StreamDBClient sdc = new StreamDBClient(config)) {
                 // Pull the records from a specific logdate to the slicetable for further processing.
-                int rows = sdc.pullToSliceTable(Date.valueOf(instantZonedDateTime.toLocalDate()));
+                final int rows = sdc.pullToSliceTable(Date.valueOf(instantZonedDateTime.toLocalDate()));
                 Assertions.assertEquals(1, rows);
                 Assertions.assertFalse(sdc.getNextHourAndSizeFromSliceTable(0L).isStub);
 
@@ -632,12 +630,12 @@ class StreamDBClientTest {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
         // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
-        Instant instant = Instant.ofEpochSecond(1696471200);
-        Instant instantPlusHour = instant.plusSeconds(3600);
-        LogfileRecord logfileRecord = logfileRecordForEpoch(instant.getEpochSecond(), false);
+        final Instant instant = Instant.ofEpochSecond(1696471200);
+        final Instant instantPlusHour = instant.plusSeconds(3600);
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(instant.getEpochSecond(), false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
         // Inserting logfile with logtime of 2023-10-05 03:00 UTC.
-        LogfileRecord logfileRecord2 = logfileRecordForEpoch(instantPlusHour.getEpochSecond(), false);
+        final LogfileRecord logfileRecord2 = logfileRecordForEpoch(instantPlusHour.getEpochSecond(), false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
@@ -650,7 +648,7 @@ class StreamDBClientTest {
         final StreamDBClient sdc = Assertions.assertDoesNotThrow(() -> new StreamDBClient(config));
 
         // Pull the records from a specific logdate to the slicetable for further processing.
-        int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
+        final int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
         Assertions.assertEquals(2, rows);
 
         // find the earliest row and assert that it has correct offset/logtime value
@@ -671,13 +669,13 @@ class StreamDBClientTest {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
         // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
-        Instant instant = Instant.ofEpochSecond(1696471200L);
-        ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
-        ZonedDateTime instantPlusHour = instantZonedDateTime.plusHours(1);
-        LogfileRecord logfileRecord = logfileRecordForEpoch(instantZonedDateTime.toEpochSecond(), true);
+        final Instant instant = Instant.ofEpochSecond(1696471200L);
+        final ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
+        final ZonedDateTime instantPlusHour = instantZonedDateTime.plusHours(1);
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(instantZonedDateTime.toEpochSecond(), true);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
         // Inserting logfile with logtime of 2023-10-04 23:00 UTC-4.
-        LogfileRecord logfileRecord2 = logfileRecordForEpoch(instantPlusHour.toEpochSecond(), true);
+        final LogfileRecord logfileRecord2 = logfileRecordForEpoch(instantPlusHour.toEpochSecond(), true);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
@@ -690,7 +688,7 @@ class StreamDBClientTest {
         Assertions.assertDoesNotThrow(() -> {
             try (final StreamDBClient sdc = new StreamDBClient(config)) {
                 // Pull the records from a specific logdate to the slicetable for further processing.
-                int rows = sdc.pullToSliceTable(Date.valueOf(instantZonedDateTime.toLocalDate()));
+                final int rows = sdc.pullToSliceTable(Date.valueOf(instantZonedDateTime.toLocalDate()));
                 Assertions.assertEquals(2, rows);
 
                 // find the earliest row and assert that it has correct offset/logtime value
@@ -712,8 +710,8 @@ class StreamDBClientTest {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
         // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
-        Instant instant = Instant.ofEpochSecond(1696471200L);
-        LogfileRecord logfileRecord = logfileRecordForEpoch(instant.getEpochSecond(), false);
+        final Instant instant = Instant.ofEpochSecond(1696471200L);
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(instant.getEpochSecond(), false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
@@ -724,20 +722,20 @@ class StreamDBClientTest {
         final Config config = new Config(opts);
         Assertions.assertDoesNotThrow(() -> {
             try (final StreamDBClient sdc = new StreamDBClient(config)) {
-                Instant instantEarliest = Instant.ofEpochSecond(1696392000L);
-                ZonedDateTime instantEarliestZonedDateTime = ZonedDateTime.ofInstant(instantEarliest, zoneId);
+                final Instant instantEarliest = Instant.ofEpochSecond(1696392000L);
+                final ZonedDateTime instantEarliestZonedDateTime = ZonedDateTime.ofInstant(instantEarliest, zoneId);
                 final long earliestEpoch = instantEarliestZonedDateTime.toEpochSecond(); // 2023-10-04 00:00 UTC-4
 
                 // Pull the records from a specific logdate to the slicetable for further processing.
-                int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
+                final int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
                 Assertions.assertEquals(1, rows);
 
                 // Get the offset for the first non-empty hour of records from the slicetable.
-                WeightedOffset nextHourAndSizeFromSliceTable = sdc.getNextHourAndSizeFromSliceTable(0L);
+                final WeightedOffset nextHourAndSizeFromSliceTable = sdc.getNextHourAndSizeFromSliceTable(0L);
                 Assertions.assertFalse(nextHourAndSizeFromSliceTable.isStub);
                 final long latestOffset = nextHourAndSizeFromSliceTable.offset();
                 // Get the record from slicetable and assert that it was found with the queryXML condition.
-                Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> hourRange = sdc
+                final Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> hourRange = sdc
                         .getHourRange(earliestEpoch, latestOffset);
                 Assertions.assertEquals(1, hourRange.size());
             }
@@ -752,8 +750,8 @@ class StreamDBClientTest {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
         // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
-        Instant instant = Instant.ofEpochSecond(1696471200L);
-        LogfileRecord logfileRecord = logfileRecordForEpoch(instant.getEpochSecond(), false);
+        final Instant instant = Instant.ofEpochSecond(1696471200L);
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(instant.getEpochSecond(), false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
 
         // Assert StreamDBClient methods work as expected with the test data.
@@ -765,7 +763,7 @@ class StreamDBClientTest {
         Assertions.assertDoesNotThrow(() -> {
             try (final StreamDBClient sdc = new StreamDBClient(config)) {
                 // Pull the records from a specific logdate to the slicetable for further processing.
-                int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
+                final int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
                 // Assert that no rows were pulled to slicetable because of queryXML condition.
                 Assertions.assertEquals(0, rows);
             }
@@ -777,22 +775,24 @@ class StreamDBClientTest {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
         // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
-        Instant instant = Instant.ofEpochSecond(1696471200L);
-        LogfileRecord corruptedLogfileRecord = logfileRecordForEpoch(instant.getEpochSecond(), false);
+        final Instant instant = Instant.ofEpochSecond(1696471200L);
+        final LogfileRecord corruptedLogfileRecord = logfileRecordForEpoch(instant.getEpochSecond(), false);
         ctx.insertInto(JOURNALDB.LOGFILE).set(corruptedLogfileRecord).execute();
         // Add the ID of the inserted logfile to corrupted_archive table
-        CorruptedArchiveRecord corruptedArchiveRecord = new CorruptedArchiveRecord(corruptedLogfileRecord.getId());
-        int insertedRows = ctx.insertInto(JOURNALDB.CORRUPTED_ARCHIVE).set(corruptedArchiveRecord).execute();
+        final CorruptedArchiveRecord corruptedArchiveRecord = new CorruptedArchiveRecord(
+                corruptedLogfileRecord.getId()
+        );
+        final int insertedRows = ctx.insertInto(JOURNALDB.CORRUPTED_ARCHIVE).set(corruptedArchiveRecord).execute();
         Assertions.assertEquals(1, insertedRows);
         final Map<String, String> opts = this.opts;
         opts.put("DBurl", mariadb.getJdbcUrl());
         final Config config = new Config(opts);
         final StreamDBClient sdc = Assertions.assertDoesNotThrow(() -> new StreamDBClient(config));
         // Pull the records from a specific logdate to the slicetable for further processing.
-        int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
+        final int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
         // Assert that the record with ID present in corrupted_archive table is not included in the query result
         Assertions.assertEquals(0, rows);
-        WeightedOffset nextHourAndSizeFromSliceTable = sdc.getNextHourAndSizeFromSliceTable(0L);
+        final WeightedOffset nextHourAndSizeFromSliceTable = sdc.getNextHourAndSizeFromSliceTable(0L);
         Assertions.assertTrue(nextHourAndSizeFromSliceTable.isStub);
     }
 
@@ -804,7 +804,7 @@ class StreamDBClientTest {
         // Add test data to logfile table in journaldb.
         final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
         // Set logdate and logtime to 2023-10-04:21 UTC-4 and set epoch_hour in path to 2023-10-05:01 UTC.
-        LogfileRecord logfileRecord = logfileRecordForEpoch(1696467600L, false);
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(1696467600L, false);
         // Insert the logfileRecord to the database using JOOQ.
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
 
@@ -820,35 +820,34 @@ class StreamDBClientTest {
         final StreamDBClient sdcUTC = Assertions.assertDoesNotThrow(() -> new StreamDBClient(configUTC));
 
         final Long earliestEpoch = 1696377600L; // 2023-10-04
-        Long latestOffset = earliestEpoch;
 
         // Pull the records from a specific logdate to the slicetable for further processing.
-        int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
+        final int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
         Assertions.assertEquals(1, rows);
         // Do the same for sdcUTC
         Assertions.assertEquals(rows, sdcUTC.pullToSliceTable(Date.valueOf("2023-10-5")));
 
         // Get the offset for the first non-empty hour of records from the slicetable.
-        WeightedOffset nextHourAndSizeFromSliceTable = sdc.getNextHourAndSizeFromSliceTable(latestOffset);
+        final WeightedOffset nextHourAndSizeFromSliceTable = sdc.getNextHourAndSizeFromSliceTable(earliestEpoch);
         Assertions.assertFalse(nextHourAndSizeFromSliceTable.isStub);
         // Do the same for sdcUTC
-        WeightedOffset nextHourAndSizeFromSliceTableUTC = sdcUTC.getNextHourAndSizeFromSliceTable(latestOffset);
+        final WeightedOffset nextHourAndSizeFromSliceTableUTC = sdcUTC.getNextHourAndSizeFromSliceTable(earliestEpoch);
         Assertions.assertFalse(nextHourAndSizeFromSliceTableUTC.isStub);
 
-        latestOffset = nextHourAndSizeFromSliceTable.offset();
+        final Long latestOffset = nextHourAndSizeFromSliceTable.offset();
         Assertions.assertEquals(latestOffset, nextHourAndSizeFromSliceTableUTC.offset());
 
         // Get the logfile results from the known hour range.
         Assertions.assertEquals(1696467600L, latestOffset);
-        Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> hourRange = sdc
+        final Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> hourRange = sdc
                 .getHourRange(earliestEpoch, latestOffset);
         Assertions.assertEquals(1, hourRange.size());
         // Do the same for sdcUTC
-        Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> hourRangeUTC = sdcUTC
+        final Result<Record9<ULong, String, String, String, String, String, Long, ULong, ULong>> hourRangeUTC = sdcUTC
                 .getHourRange(earliestEpoch, latestOffset);
         Assertions.assertEquals(1, hourRangeUTC.size());
         // Assert that the resulting logfile metadata is as expected for logtime, they should not be affected by session timezone.
-        ZonedDateTime zonedDateTimeUTC = ZonedDateTime.of(2023, 10, 5, 1, 0, 0, 0, ZoneId.of("UTC"));
+        final ZonedDateTime zonedDateTimeUTC = ZonedDateTime.of(2023, 10, 5, 1, 0, 0, 0, ZoneId.of("UTC"));
         Assertions.assertEquals(zonedDateTimeUTC.toEpochSecond(), hourRange.get(0).get(6, Long.class));
         Assertions.assertEquals(zonedDateTimeUTC.toEpochSecond(), hourRangeUTC.get(0).get(6, Long.class));
     }

--- a/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
@@ -854,6 +854,90 @@ class StreamDBClientTest {
     }
 
     @Test
+    public void earliestConditionInclusionTest() {
+        // Add test data to logfile table in journaldb.
+        final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
+        // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
+        final Map<String, String> opts = new HashMap<>(this.opts);
+        opts.put("DBurl", mariadb.getJdbcUrl());
+        // Set the queryXML earliest epoch_hour to 1696471200 greater or equal, which is the epoch_hour of the inserted logfile.
+        opts.put("queryXML", "<earliest value=\"1696471200\" operation=\"GE\"/>");
+        final Config config = new Config(opts);
+        Assertions.assertDoesNotThrow(() -> {
+            try (final StreamDBClient sdc = new StreamDBClient(config)) {
+                // The row with epoch_hour referring to 2023-10-5 should be pulled to slicetable.
+                final int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
+                Assertions.assertEquals(1, rows);
+            }
+        });
+    }
+
+    @Test
+    public void earliestConditionExclusionTest() {
+        // Add test data to logfile table in journaldb.
+        final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
+        // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
+        final Map<String, String> opts = new HashMap<>(this.opts);
+        opts.put("DBurl", mariadb.getJdbcUrl());
+        // Set the queryXML earliest epoch_hour to 1696471201 greater or equal, filtering out the inserted logfile.
+        opts.put("queryXML", "<earliest value=\"1696471201\" operation=\"GE\"/>");
+        final Config config = new Config(opts);
+        Assertions.assertDoesNotThrow(() -> {
+            try (final StreamDBClient sdc = new StreamDBClient(config)) {
+                // No rows with epoch_hour referring to 2023-10-5 should be pulled to slicetable.
+                final int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
+                Assertions.assertEquals(0, rows);
+            }
+        });
+    }
+
+    @Test
+    public void latestConditionInclusionTest() {
+        // Add test data to logfile table in journaldb.
+        final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
+        // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
+        final Map<String, String> opts = new HashMap<>(this.opts);
+        opts.put("DBurl", mariadb.getJdbcUrl());
+        // Set the queryXML latest epoch_hour to 1696471200 less or equal, which is the epoch_hour of the inserted logfile.
+        opts.put("queryXML", "<latest value=\"1696471200\" operation=\"LE\"/>");
+        final Config config = new Config(opts);
+        Assertions.assertDoesNotThrow(() -> {
+            try (final StreamDBClient sdc = new StreamDBClient(config)) {
+                // The row with epoch_hour referring to 2023-10-5 should be pulled to slicetable.
+                final int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
+                Assertions.assertEquals(1, rows);
+            }
+        });
+    }
+
+    @Test
+    public void latestConditionExclusionTest() {
+        // Add test data to logfile table in journaldb.
+        final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
+        // Set logdate and logtime to 2023-10-04:22 UTC-4 and set epoch_hour in path to 2023-10-05:02 UTC.
+        final LogfileRecord logfileRecord = logfileRecordForEpoch(1696471200L, false);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
+        final Map<String, String> opts = new HashMap<>(this.opts);
+        opts.put("DBurl", mariadb.getJdbcUrl());
+        // Set the queryXML latest epoch_hour to 1696471199 less or equal, filtering out the inserted logfile.
+        opts.put("queryXML", "<latest value=\"1696471199\" operation=\"LE\"/>");
+        final Config config = new Config(opts);
+        Assertions.assertDoesNotThrow(() -> {
+            try (final StreamDBClient sdc = new StreamDBClient(config)) {
+                // No rows with epoch_hour referring to 2023-10-5 should be pulled to slicetable.
+                final int rows = sdc.pullToSliceTable(Date.valueOf("2023-10-5"));
+                Assertions.assertEquals(0, rows);
+            }
+        });
+    }
+
+    @Test
     public void equalsHashCodeContractTest() {
         EqualsVerifier
                 .forClass(StreamDBClient.class)

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
@@ -48,6 +48,7 @@ package com.teragrep.pth_06.planner.walker.conditions;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -60,10 +61,8 @@ public class EarliestConditionTest {
 
     @Test
     public void conditionTest() {
-        String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" >= date '1970-01-01'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 0)\n"
-                + ")";
-        Condition elementCondition = new EarliestCondition("1000").condition();
+        final String e = "\"journaldb\".\"logfile\".\"epoch_hour\" >= 1000";
+        final Condition elementCondition = new EarliestCondition("1000").condition();
         Assertions.assertEquals(e, elementCondition.toString());
     }
 
@@ -74,8 +73,15 @@ public class EarliestConditionTest {
     }
 
     @Test
+    @Disabled("EarliestCondition now uses ULong epoch_hour and does not allow negative values")
     public void largeNegativeNumberInputTest() {
         final QueryCondition earliestCondition = new EarliestCondition("-29786022887");
+        Assertions.assertDoesNotThrow(earliestCondition::condition);
+    }
+
+    @Test
+    public void zeroInputTest() {
+        final QueryCondition earliestCondition = new EarliestCondition("0");
         Assertions.assertDoesNotThrow(earliestCondition::condition);
     }
 

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
@@ -48,7 +48,6 @@ package com.teragrep.pth_06.planner.walker.conditions;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -73,10 +72,9 @@ public class EarliestConditionTest {
     }
 
     @Test
-    @Disabled("EarliestCondition now uses ULong epoch_hour and does not allow negative values")
-    public void largeNegativeNumberInputTest() {
-        final QueryCondition earliestCondition = new EarliestCondition("-29786022887");
-        Assertions.assertDoesNotThrow(earliestCondition::condition);
+    public void negativeNumberInputExceptionTest() {
+        final QueryCondition earliestCondition = new EarliestCondition("-1");
+        Assertions.assertThrows(NumberFormatException.class, () -> earliestCondition.condition());
     }
 
     @Test

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ElementConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/ElementConditionTest.java
@@ -142,16 +142,16 @@ public final class ElementConditionTest {
 
     @Test
     public void testTimeQualifiers() {
-        String[] tags = {
+        final String[] tags = {
                 "earliest", "latest", "index_earliest", "index_latest"
         };
         int loops = 0;
-        for (String tag : tags) {
-            Element element = document.createElement(tag);
+        for (final String tag : tags) {
+            final Element element = document.createElement(tag);
             element.setAttribute("value", "1000");
             element.setAttribute("operation", "EQUALS");
-            Condition condition = new ElementCondition(element, config).condition();
-            Assertions.assertTrue(condition.toString().contains("date"));
+            final Condition condition = new ElementCondition(element, config).condition();
+            Assertions.assertTrue(condition.toString().contains("epoch_hour"));
             loops++;
         }
         Assertions.assertEquals(4, loops);

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
@@ -48,6 +48,7 @@ package com.teragrep.pth_06.planner.walker.conditions;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -60,19 +61,15 @@ public class LatestConditionTest {
 
     @Test
     public void conditionTest() {
-        String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" <= date '1970-01-01'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1000)\n"
-                + ")";
-        Condition elementCondition = new LatestCondition("1000").condition();
+        final String e = "\"journaldb\".\"logfile\".\"epoch_hour\" <= 1000";
+        final Condition elementCondition = new LatestCondition("1000").condition();
         Assertions.assertEquals(e, elementCondition.toString());
     }
 
     @Test
     public void conditionUpdatedTest() {
-        String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" <= date '2000-01-01'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 946720800)\n"
-                + ")";
-        Condition elementCondition = new LatestCondition("946720800").condition();
+        final String e = "\"journaldb\".\"logfile\".\"epoch_hour\" <= 946720800";
+        final Condition elementCondition = new LatestCondition("946720800").condition();
         Assertions.assertEquals(e, elementCondition.toString());
     }
 
@@ -83,35 +80,42 @@ public class LatestConditionTest {
     }
 
     @Test
+    @Disabled("LatestCondition now uses ULong epoch_hour and does not allow negative values")
     public void largeNegativeNumberInputTest() {
         final QueryCondition eq = new LatestCondition("-29786022887");
         Assertions.assertDoesNotThrow(eq::condition);
     }
 
     @Test
+    public void zeroInputTest() {
+        final QueryCondition latestCondition = new LatestCondition("0");
+        Assertions.assertDoesNotThrow(latestCondition::condition);
+    }
+
+    @Test
     public void equalsTest() {
-        LatestCondition eq1 = new LatestCondition("946720800");
+        final LatestCondition eq1 = new LatestCondition("946720800");
         eq1.condition();
-        LatestCondition eq2 = new LatestCondition("946720800");
-        LatestCondition eq3 = new LatestCondition("946720800");
+        final LatestCondition eq2 = new LatestCondition("946720800");
+        final LatestCondition eq3 = new LatestCondition("946720800");
         eq3.condition();
-        LatestCondition eq4 = new LatestCondition("946720800");
+        final LatestCondition eq4 = new LatestCondition("946720800");
         Assertions.assertEquals(eq1, eq2);
         Assertions.assertEquals(eq3, eq4);
     }
 
     @Test
     public void notEqualsTest() {
-        LatestCondition eq1 = new LatestCondition("946720800");
-        LatestCondition notEq = new LatestCondition("1000");
+        final LatestCondition eq1 = new LatestCondition("946720800");
+        final LatestCondition notEq = new LatestCondition("1000");
         Assertions.assertNotEquals(eq1, notEq);
     }
 
     @Test
     public void hashCodeTest() {
-        LatestCondition eq1 = new LatestCondition("946720800");
-        LatestCondition eq2 = new LatestCondition("946720800");
-        LatestCondition notEq = new LatestCondition("1000");
+        final LatestCondition eq1 = new LatestCondition("946720800");
+        final LatestCondition eq2 = new LatestCondition("946720800");
+        final LatestCondition notEq = new LatestCondition("1000");
         Assertions.assertEquals(eq1.hashCode(), eq2.hashCode());
         Assertions.assertNotEquals(eq1.hashCode(), notEq.hashCode());
     }

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
@@ -48,7 +48,6 @@ package com.teragrep.pth_06.planner.walker.conditions;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jooq.Condition;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -80,10 +79,9 @@ public class LatestConditionTest {
     }
 
     @Test
-    @Disabled("LatestCondition now uses ULong epoch_hour and does not allow negative values")
-    public void largeNegativeNumberInputTest() {
-        final QueryCondition eq = new LatestCondition("-29786022887");
-        Assertions.assertDoesNotThrow(eq::condition);
+    public void negativeNumberInputExceptionTest() {
+        final QueryCondition eq = new LatestCondition("-1");
+        Assertions.assertThrows(NumberFormatException.class, () -> eq.condition());
     }
 
     @Test

--- a/src/test/java/com/teragrep/pth_06/walker/ConditionWalkerTest.java
+++ b/src/test/java/com/teragrep/pth_06/walker/ConditionWalkerTest.java
@@ -246,17 +246,14 @@ public class ConditionWalkerTest {
 
     @Test
     void withoutFiltersEnabledWithTimeConstraints() {
-        DSLContext ctx = DSL.using(conn);
-        ConditionWalker walker = new ConditionWalker(ctx, true, new FilterlessSearchImpl(ctx, ipRegex));
-        String q = "<AND><index operation=\"EQUALS\" value=\"haproxy\"/><AND><earliest operation=\"GE\" value=\"1643207821\"/><latest operation=\"LE\" value=\"1729435021\"/></AND></AND>";
-        String e = "(\n" + "  \"bloomdb\".\"pattern_test_ip\".\"filter\" is null\n"
+        final DSLContext ctx = DSL.using(conn);
+        final ConditionWalker walker = new ConditionWalker(ctx, true, new FilterlessSearchImpl(ctx, ipRegex));
+        final String q = "<AND><index operation=\"EQUALS\" value=\"haproxy\"/><AND><earliest operation=\"GE\" value=\"1643207821\"/><latest operation=\"LE\" value=\"1729435021\"/></AND></AND>";
+        final String e = "(\n" + "  \"bloomdb\".\"pattern_test_ip\".\"filter\" is null\n"
                 + "  and \"getArchivedObjects_filter_table\".\"directory\" like 'haproxy'\n"
-                + "  and \"journaldb\".\"logfile\".\"logdate\" >= date '2022-01-26'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1643205600)\n"
-                + "  and \"journaldb\".\"logfile\".\"logdate\" <= date '2024-10-20'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1729435021)\n"
-                + ")";
-        Condition cond = Assertions.assertDoesNotThrow(() -> walker.fromString(q, false));
+                + "  and \"journaldb\".\"logfile\".\"epoch_hour\" >= 1643207821\n"
+                + "  and \"journaldb\".\"logfile\".\"epoch_hour\" <= 1729435021\n" + ")";
+        final Condition cond = Assertions.assertDoesNotThrow(() -> walker.fromString(q, false));
         Assertions.assertEquals(e, cond.toString());
         Assertions.assertEquals(1, walker.conditionRequiredTables().size());
         Assertions
@@ -294,15 +291,12 @@ public class ConditionWalkerTest {
 
     @Test
     void testFullXMLTwoMatchingTables() {
-        ConditionWalker walker = new ConditionWalker(DSL.using(conn), true);
-        String q = "<AND><index operation=\"EQUALS\" value=\"search_bench\"/><AND><AND><AND><earliest operation=\"GE\" value=\"1643207821\"/><latest operation=\"LE\" value=\"1729435021\"/></AND><indexstatement operation=\"EQUALS\" value=\"192.168.1.1\"/></AND><indexstatement operation=\"EQUALS\" value=\"192.000.1.1\"/></AND></AND>";
-        String e = "(\n" + "  \"getArchivedObjects_filter_table\".\"directory\" like 'search_bench'\n"
-                + "  and \"journaldb\".\"logfile\".\"logdate\" >= date '2022-01-26'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1643205600)\n"
-                + "  and \"journaldb\".\"logfile\".\"logdate\" <= date '2024-10-20'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1729435021)\n"
-                + "  and (\n" + "    (\n" + "      bloommatch(\n" + "        (\n"
-                + "          select \"term_0_pattern_test_ip\".\"filter\"\n"
+        final ConditionWalker walker = new ConditionWalker(DSL.using(conn), true);
+        final String q = "<AND><index operation=\"EQUALS\" value=\"search_bench\"/><AND><AND><AND><earliest operation=\"GE\" value=\"1643207821\"/><latest operation=\"LE\" value=\"1729435021\"/></AND><indexstatement operation=\"EQUALS\" value=\"192.168.1.1\"/></AND><indexstatement operation=\"EQUALS\" value=\"192.000.1.1\"/></AND></AND>";
+        final String e = "(\n" + "  \"getArchivedObjects_filter_table\".\"directory\" like 'search_bench'\n"
+                + "  and \"journaldb\".\"logfile\".\"epoch_hour\" >= 1643207821\n"
+                + "  and \"journaldb\".\"logfile\".\"epoch_hour\" <= 1729435021\n" + "  and (\n" + "    (\n"
+                + "      bloommatch(\n" + "        (\n" + "          select \"term_0_pattern_test_ip\".\"filter\"\n"
                 + "          from \"term_0_pattern_test_ip\"\n" + "          where (\n" + "            term_id = 0\n"
                 + "            and type_id = \"bloomdb\".\"pattern_test_ip\".\"filter_type_id\"\n" + "          )\n"
                 + "        ),\n" + "        \"bloomdb\".\"pattern_test_ip\".\"filter\"\n" + "      ) = true\n"
@@ -314,7 +308,7 @@ public class ConditionWalkerTest {
                 + "        ),\n" + "        \"bloomdb\".\"pattern_test_ip\".\"filter\"\n" + "      ) = true\n"
                 + "      and \"bloomdb\".\"pattern_test_ip\".\"filter\" is not null\n" + "    )\n"
                 + "    or \"bloomdb\".\"pattern_test_ip\".\"filter\" is null\n" + "  )\n" + ")";
-        Condition cond = Assertions.assertDoesNotThrow(() -> walker.fromString(q, false));
+        final Condition cond = Assertions.assertDoesNotThrow(() -> walker.fromString(q, false));
         Assertions.assertEquals(e, cond.toString());
     }
 

--- a/src/test/java/com/teragrep/pth_06/walker/XmlWalkerTest.java
+++ b/src/test/java/com/teragrep/pth_06/walker/XmlWalkerTest.java
@@ -52,7 +52,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class XmlWalkerTest {
 
@@ -178,8 +178,8 @@ public class XmlWalkerTest {
     }
 
     @Test
-    void fromStringTimeRangesTest() throws Exception {
-        String q, e, result;
+    void fromStringTimeRangesTest() {
+        final String q, e, result;
         // Drop indexstring and earliest from query
         q = "<OR><AND><AND><index value=\"haproxy\" operation=\"NOT_EQUALS\"/><sourcetype value=\"example:haproxy:haproxy\" operation=\"EQUALS\"/></AND><host value=\"loadbalancer.example.com\" operation=\"EQUALS\"/></AND><AND><AND><AND><index value=\"*\" operation=\"EQUALS\"/><host value=\"firewall.example.com\" operation=\"EQUALS\"/></AND><earliest value=\"1611657303\" operation=\"GE\"/></AND><indexstring value=\"Denied\" /></AND></OR>";
         e = "(\n" + "  (\n" + "    not (\"getArchivedObjects_filter_table\".\"directory\" like 'haproxy')\n"
@@ -187,50 +187,38 @@ public class XmlWalkerTest {
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'loadbalancer.example.com'\n" + "  )\n"
                 + "  or (\n" + "    true\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'firewall.example.com'\n"
-                + "    and \"journaldb\".\"logfile\".\"logdate\" >= date '2021-01-26'\n"
-                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1611655200)\n"
-                + "  )\n" + ")";
-        result = conditionWalker.fromString(q, false).toString();
+                + "    and \"journaldb\".\"logfile\".\"epoch_hour\" >= 1611657303\n" + "  )\n" + ")";
+        result = assertDoesNotThrow(() -> conditionWalker.fromString(q, false).toString());
         assertEquals(e, result);
     }
 
     @Test
-    void fromStringTimeRangesUsingEpochTest() throws Exception {
-        String q, e, result;
+    void fromStringTimeRangesUsingEpochTest() {
+        final String q, e, result;
         q = "<OR><AND><AND><index value=\"haproxy\" operation=\"NOT_EQUALS\"/><sourcetype value=\"example:haproxy:haproxy\" operation=\"EQUALS\"/></AND><host value=\"loadbalancer.example.com\" operation=\"EQUALS\"/></AND><AND><AND><AND><AND><index value=\"*\" operation=\"EQUALS\"/><host value=\"firewall.example.com\" operation=\"EQUALS\"/></AND><earliest value=\"1611657303\" operation=\"GE\"/></AND><latest value=\"1619437701\" operation=\"LE\"/></AND><indexstring value=\"Denied\" /></AND></OR>";
         e = "(\n" + "  (\n" + "    not (\"getArchivedObjects_filter_table\".\"directory\" like 'haproxy')\n"
                 + "    and \"getArchivedObjects_filter_table\".\"stream\" like 'example:haproxy:haproxy'\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'loadbalancer.example.com'\n" + "  )\n"
                 + "  or (\n" + "    true\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'firewall.example.com'\n"
-                + "    and \"journaldb\".\"logfile\".\"logdate\" >= date '2021-01-26'\n"
-                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1611655200)\n"
-                + "    and \"journaldb\".\"logfile\".\"logdate\" <= date '2021-04-26'\n"
-                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1619437701)\n"
-                + "  )\n" + ")";
-        Condition cond = conditionWalker.fromString(q, false);
-        if (cond != null) {
-            result = conditionWalker.fromString(q, false).toString();
-        }
-        else {
-            result = "illegal null condition";
-        }
+                + "    and \"journaldb\".\"logfile\".\"epoch_hour\" >= 1611657303\n"
+                + "    and \"journaldb\".\"logfile\".\"epoch_hour\" <= 1619437701\n" + "  )\n" + ")";
+        final Condition cond = assertDoesNotThrow(() -> conditionWalker.fromString(q, false));
+        assertNotNull(cond);
+        result = assertDoesNotThrow(() -> conditionWalker.fromString(q, false).toString());
         assertEquals(e, result);
     }
 
     @Test
-    void fromStringTimeRanges0ToEpochTest() throws Exception {
-        String q, e, result;
+    void fromStringTimeRanges0ToEpochTest() {
+        final String q, e, result;
         q = "<AND><AND><AND><host value=\"sc-99-99-14-25\" operation=\"EQUALS\"/><index value=\"cpu\" operation=\"EQUALS\"/></AND><sourcetype value=\"log:cpu:0\" operation=\"EQUALS\"/></AND><AND><earliest value=\"0\" operation=\"GE\"/><latest value=\"1893491420\" operation=\"LE\"/></AND></AND>";
         e = "(\n" + "  \"getArchivedObjects_filter_table\".\"host\" like 'sc-99-99-14-25'\n"
                 + "  and \"getArchivedObjects_filter_table\".\"directory\" like 'cpu'\n"
                 + "  and \"getArchivedObjects_filter_table\".\"stream\" like 'log:cpu:0'\n"
-                + "  and \"journaldb\".\"logfile\".\"logdate\" >= date '1970-01-01'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 0)\n"
-                + "  and \"journaldb\".\"logfile\".\"logdate\" <= date '2030-01-01'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1893491420)\n"
-                + ")";
-        Condition cond = conditionWalker.fromString(q, false);
+                + "  and \"journaldb\".\"logfile\".\"epoch_hour\" >= 0\n"
+                + "  and \"journaldb\".\"logfile\".\"epoch_hour\" <= 1893491420\n" + ")";
+        final Condition cond = assertDoesNotThrow(() -> conditionWalker.fromString(q, false));
         result = cond.toString();
         assertEquals(e, result);
     }

--- a/src/test/resources/CREATE_STREAMDB_DB.sql
+++ b/src/test/resources/CREATE_STREAMDB_DB.sql
@@ -164,6 +164,7 @@ CREATE TABLE `corrupted_archive` (
 INSERT INTO logtag (id, logtag) VALUES (1, 'example');
 INSERT INTO host (id, name) VALUES (1, 'testHost1');
 INSERT INTO bucket (id, name) VALUES (1, 'bucket1');
+INSERT INTO bucket (id, name) VALUES (2, 'bucket2');
 INSERT INTO category (id, name) VALUES (1, 'testCategory');
 INSERT INTO source_system (id, name) VALUES (2, 'testSourceSystem2');
 flush privileges;


### PR DESCRIPTION
## Description

The aim of this pull request is to implement support for new epoch time columns to logfile metadata queries done by StreamDBClient. Original logdate and logtime implementations are prone to timezone issues where the result of the query changes depending on the session timezone, using epoch time resolves this issue.

Includes:
- Added support for using epoch_hour column as a source for logtime result value.
- Removed support for using old logdate and logtime implementation.
- New tests for asserting the query changes work as expected.
- Renamed and disabled old logdate implementation tests.
- Fixed weightedOffsetTest which was not using whole hours for logtime values.

Resolves #213
Resolves #214 
Resolves #284

## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods. 

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [x] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.  
