### PR TITLE
add workflow to upload release to GitHub packages

### DIFF
--- a/.github/workflows/upload_release_github_packages.yaml
+++ b/.github/workflows/upload_release_github_packages.yaml
@@ -9,7 +9,6 @@ jobs:
     name: Upload
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       packages: write
 
     steps:
@@ -32,9 +31,9 @@ jobs:
       - name: Publish to GitHub Packages
         run: | 
           if [ "${{ github.repository_owner }}" = "teragrep" ]; then 
-            mvn --batch-mode -Drevision=${{ github.event.release.tag_name }} -Dsha1= -Dchangelist= -Dgithub.packages.url="https://maven.pkg.github.com/${{ github.repository_owner }}/pth_06" clean deploy -Ppublish-github-packages
+            mvn --batch-mode -Drevision=${{ github.event.release.tag_name }} -Dsha1= -Dchangelist= -Dgpg.skip=true clean deploy -Ppublish-github-packages
           else
-            mvn --batch-mode -Drevision=${{ github.event.release.tag_name }}-${{ github.actor }} -Dsha1= -Dchangelist= -Dgithub.packages.url="https://maven.pkg.github.com/${{ github.repository_owner }}/pth_06" -Dgpg.skip=true clean deploy -Ppublish-github-packages
+            mvn --batch-mode -Drevision=${{ github.event.release.tag_name }}-${{ github.actor }} -Dsha1= -Dchangelist= -Dgpg.skip=true clean deploy -Ppublish-github-packages
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -782,36 +782,12 @@
         <repository>
           <id>github</id>
           <name>GitHub Packages</name>
-          <url>${github.packages.url}</url>
+          <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
         </repository>
       </distributionManagement>
       <properties>
         <jooq.regenerate.skip>true</jooq.regenerate.skip>
       </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-                <phase>verify</phase>
-                <configuration>
-                  <gpgArguments>
-                    <arg>--pinentry-mode</arg>
-                    <arg>loopback</arg>
-                  </gpgArguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
## Description

Allows for publishing releases as GitHub Packages based on mvn_01 example.

- jooq regeneration is skipped for this step
- in the main repository a gpg sign in is required and the GitHub packages version will match the release tag
- in a fork, gpg sign in is skipped
- in a fork the package version will include the github actors name to differentiate it from the main repo releases, example verison in GitHub packages: 

```
<dependency>
  <groupId>com.teragrep</groupId>
  <artifactId>pth_06</artifactId>
  <version>v1.0.5-elliVM</version>
</dependency> 
```
