### PR TITLE
fix: use source fragment's own isStub value determine fallback

### DIFF
--- a/src/main/java/com/teragrep/pth_06/task/s3/RowConverter.java
+++ b/src/main/java/com/teragrep/pth_06/task/s3/RowConverter.java
@@ -348,7 +348,7 @@ public final class RowConverter {
         }
 
         Fragment sourceSourceFragment = rfc5424Frame.structuredData.getValue(eventNodeSourceSource);
-        if (sourceHostnameFragment.isStub) {
+        if (sourceSourceFragment.isStub) {
             sourceSourceFragment = rfc5424Frame.structuredData.getValue(eventNodeRelaySource);
         }
 


### PR DESCRIPTION
## Description
one-line fix to use correct source `Fragment` to check `isStub` value.
