### PR TITLE
parse xml value to long instead of int in earliest and latest condition 

### DIFF
--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/EarliestCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/EarliestCondition.java
@@ -64,8 +64,8 @@ public final class EarliestCondition implements QueryCondition {
     public Condition condition() {
         // SQL connection uses localTime in the session, so we use unix to come over the conversions
         // hour based files are being used so earliest needs conversion to the point of the last hour
-        final int earliestFromElement = Integer.parseInt(value);
-        final int earliestEpochHour = earliestFromElement - earliestFromElement % 3600;
+        final long earliestFromElement = Long.parseLong(value);
+        final long earliestEpochHour = earliestFromElement - earliestFromElement % 3600;
         final Instant instant = Instant.ofEpochSecond(earliestEpochHour);
         final java.sql.Date timeQualifier = new Date(instant.toEpochMilli());
         Condition condition;

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/LatestCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/LatestCondition.java
@@ -63,7 +63,8 @@ public final class LatestCondition implements QueryCondition {
 
     public Condition condition() {
         // SQL connection uses localTime in the session, so we use unix to come over the conversions
-        final Instant instant = Instant.ofEpochSecond(Integer.parseInt(value));
+        final long epochSeconds = Long.parseLong(value);
+        final Instant instant = Instant.ofEpochSecond(epochSeconds);
         final java.sql.Date timeQualifier = new Date(instant.toEpochMilli());
         Condition condition;
         condition = JOURNALDB.LOGFILE.LOGDATE.lessOrEqual(timeQualifier);

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
@@ -68,6 +68,18 @@ public class EarliestConditionTest {
     }
 
     @Test
+    public void largePositiveNumberInputTest() {
+        final QueryCondition earliestCondition = new EarliestCondition("29786022887");
+        Assertions.assertDoesNotThrow(earliestCondition::condition);
+    }
+
+    @Test
+    public void largeNegativeNumberInputTest() {
+        final QueryCondition earliestCondition = new EarliestCondition("-29786022887");
+        Assertions.assertDoesNotThrow(earliestCondition::condition);
+    }
+
+    @Test
     public void equalsTest() {
         EarliestCondition eq1 = new EarliestCondition("946677600");
         EarliestCondition eq2 = new EarliestCondition("946677600");

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
@@ -77,6 +77,18 @@ public class LatestConditionTest {
     }
 
     @Test
+    public void largePositiveNumberInputTest() {
+        final QueryCondition latestCondition = new LatestCondition("29786022887");
+        Assertions.assertDoesNotThrow(latestCondition::condition);
+    }
+
+    @Test
+    public void largeNegativeNumberInputTest() {
+        final QueryCondition eq = new LatestCondition("-29786022887");
+        Assertions.assertDoesNotThrow(eq::condition);
+    }
+
+    @Test
     public void equalsTest() {
         LatestCondition eq1 = new LatestCondition("946720800");
         eq1.condition();


### PR DESCRIPTION
## Description

Solves: #318 
`EarliestCondition` and `LatestCondition` objects used to parse the incoming value to int which can cause `NumberFormatException` with large numbers. Switched to use long 

## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

Add testing for large numbers for both objects

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods. 

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [x] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.  
