### PR TITLE
close kafka consumer after streaming query has stopped

### DIFF
--- a/src/main/java/com/teragrep/pth_06/planner/KafkaQuery.java
+++ b/src/main/java/com/teragrep/pth_06/planner/KafkaQuery.java
@@ -48,6 +48,7 @@ package com.teragrep.pth_06.planner;
 import com.teragrep.pth_06.planner.offset.KafkaOffset;
 import org.apache.kafka.common.TopicPartition;
 
+import java.io.Closeable;
 import java.util.Map;
 
 /**
@@ -56,7 +57,7 @@ import java.util.Map;
  * @since 08/06/2022
  * @author Mikko Kortelainen
  */
-public interface KafkaQuery {
+public interface KafkaQuery extends Closeable {
 
     public abstract Map<TopicPartition, Long> getInitialEndOffsets();
 
@@ -65,6 +66,4 @@ public interface KafkaQuery {
     public abstract Map<TopicPartition, Long> getBeginningOffsets(KafkaOffset endOffset);
 
     public abstract void commit(KafkaOffset offset);
-
-    public abstract void close();
 }

--- a/src/main/java/com/teragrep/pth_06/planner/KafkaQueryProcessor.java
+++ b/src/main/java/com/teragrep/pth_06/planner/KafkaQueryProcessor.java
@@ -51,6 +51,7 @@ import com.teragrep.pth_06.planner.offset.KafkaOffset;
 import com.teragrep.pth_06.planner.walker.KafkaWalker;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
@@ -266,9 +267,14 @@ public class KafkaQueryProcessor implements KafkaQuery {
     }
 
     @Override
-    public void close() {
+    public void close() throws IOException {
         LOGGER.debug("close() called unsubscribing and closing consumer");
-        kafkaConsumer.unsubscribe();
-        kafkaConsumer.close(Duration.ofSeconds(30));
+        try {
+            kafkaConsumer.unsubscribe();
+            kafkaConsumer.close(Duration.ofSeconds(30));
+        }
+        catch (final KafkaException | IllegalArgumentException exception) {
+            throw new IOException("Error during closing: " + exception.getMessage(), exception);
+        }
     }
 }


### PR DESCRIPTION
## Description

Aims to solve: #332 

Closes the `KafkaConsumer` of the `KafkaQuery` after a streaming query has stopped and spark calls `stop()` method.

## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

#### General

- [ ] I have checked that my test files and functions have meaningful names.
- [ ] I have checked that each test tests only a single behavior.
- [ ] I have done happy tests.
- [ ] I have tested only my own code.
- [ ] I have tested at least all public methods. 

#### Assertions

- [ ] I have checked that my tests use assertions and not runtime overhead.
- [ ] I have checked that my tests end in assertions.
- [ ] I have checked that there is no comparison statements in assertions.
- [ ] I have checked that assertions are in tests and not in helper functions.
- [ ] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [ ] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [ ] I have tested algorithms and anything else with the possibility of unbound growth.
- [ ] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [ ] I have checked that all test files are standalone.
- [ ] I have checked that all test-specific fake objects and classes are in the test directory.
- [ ] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [ ] I have checked that my tests do not contain non-generic information.
- [ ] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [ ] I have checked that my tests do not use throws for exceptions.
- [ ] I have checked that my tests do not use try-catch statements.
- [ ] I have checked that my tests do not use if-else statements.

#### Java

- [ ] I have checked that my tests for Java uses JUnit library.
- [ ] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [ ] I have only tested public behavior and not private implementation details.
- [ ] I have checked that my tests are not (partially) commented out.
- [ ] I have checked that hand-crafted variables in assertions are used accordingly.
- [ ] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [ ] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [ ] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [ ] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [ ] I have checked that my code follows metrics set in Procedure: Object Quality.
- [ ] I have checked that my code does not have any NULL values.
- [ ] I have checked my code does not contain FIXME or TODO comments.  
