### PR TITLE
Updated regular expression used in EarliestCondition and LatestCondition classes

### DIFF
--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/EarliestCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/EarliestCondition.java
@@ -72,7 +72,7 @@ public final class EarliestCondition implements QueryCondition {
         condition = JOURNALDB.LOGFILE.LOGDATE.greaterOrEqual(timeQualifier);
         condition = condition
                 .and(
-                        "UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H'))"
+                        "UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H'))"
                                 + " >= " + instant.getEpochSecond()
                 );
         // raw SQL used here since following not supported for mariadb:

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/LatestCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/LatestCondition.java
@@ -70,7 +70,7 @@ public final class LatestCondition implements QueryCondition {
         condition = JOURNALDB.LOGFILE.LOGDATE.lessOrEqual(timeQualifier);
         condition = condition
                 .and(
-                        "UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H'))"
+                        "UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H'))"
                                 + " <= " + instant.getEpochSecond()
                 );
         // raw SQL used here since following not supported for mariadb:

--- a/src/test/java/com/teragrep/pth_06/XmlToSqlTest.java
+++ b/src/test/java/com/teragrep/pth_06/XmlToSqlTest.java
@@ -171,7 +171,7 @@ public class XmlToSqlTest {
                 + "  or (\n" + "    true\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'firewall.example.com'\n"
                 + "    and \"journaldb\".\"logfile\".\"logdate\" >= date '" + fromDate + "'\n"
-                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= "
+                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= "
                 + fromTime.getEpochSecond() + ")\n" + "  )\n" + ")";
         result = parser.fromString(q, false).toString();
         LOGGER.debug("Query=" + q);
@@ -196,7 +196,7 @@ public class XmlToSqlTest {
                 + "  or (\n" + "    true\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'firewall.example.com'\n"
                 + "    and \"journaldb\".\"logfile\".\"logdate\" <= date '" + fromDate + "'\n"
-                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= "
+                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= "
                 + fromTime.getEpochSecond() + ")\n" + "  )\n" + ")";
         result = parser.fromString(q, false).toString();
         LOGGER.debug("Query=" + q);
@@ -222,10 +222,10 @@ public class XmlToSqlTest {
                 + "  or (\n" + "    true\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'firewall.example.com'\n"
                 + "    and \"journaldb\".\"logfile\".\"logdate\" >= date '" + fromDate + "'\n"
-                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= "
+                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= "
                 + fromTime.getEpochSecond() + ")\n" + "    and \"journaldb\".\"logfile\".\"logdate\" <= date '" + toDate
                 + "'\n"
-                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= "
+                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= "
                 + toTime.getEpochSecond() + ")\n" + "  )\n" + ")";
         result = parser.fromString(q, false).toString();
         LOGGER.debug("Query=" + q);
@@ -250,10 +250,10 @@ public class XmlToSqlTest {
                 + "  and \"getArchivedObjects_filter_table\".\"directory\" like 'cpu'\n"
                 + "  and \"getArchivedObjects_filter_table\".\"stream\" like 'log:cpu:0'\n"
                 + "  and \"journaldb\".\"logfile\".\"logdate\" >= date '" + fromDate + "'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= "
+                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= "
                 + fromTime.getEpochSecond() + ")\n" + "  and \"journaldb\".\"logfile\".\"logdate\" <= date '" + toDate
                 + "'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= "
+                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= "
                 + toTime.getEpochSecond() + ")\n" + ")";
         result = parser.fromString(q, false).toString();
         LOGGER.debug("Query=" + q);

--- a/src/test/java/com/teragrep/pth_06/planner/EarliestConditionQueryTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/EarliestConditionQueryTest.java
@@ -1,0 +1,259 @@
+/*
+ * Teragrep Archive Datasource (pth_06)
+ * Copyright (C) 2021-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.pth_06.planner;
+
+import com.teragrep.pth_06.config.Config;
+import com.teragrep.pth_06.jooq.generated.journaldb.tables.records.LogfileRecord;
+import org.jooq.*;
+import org.jooq.impl.DSL;
+import org.jooq.types.ULong;
+import org.jooq.types.UShort;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+import java.sql.*;
+import java.time.*;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.teragrep.pth_06.jooq.generated.journaldb.Journaldb.JOURNALDB;
+
+class EarliestConditionQueryTest {
+
+    private MariaDBContainer<?> mariadb;
+    private Connection connection;
+    // Set the zoneId to system default
+    private final ZoneId zoneId = ZoneId.systemDefault();
+    private final String streamDBUsername = "streamdb";
+    private final String streamDBPassword = "streamdb_pass";
+
+    private final String streamdbName = "streamdb";
+    private final String journaldbName = "journaldb";
+    private final Map<String, String> opts = new HashMap<String, String>() {
+
+        {
+            put("S3endPoint", "mock");
+            put("S3identity", "mock");
+            put("S3credential", "mock");
+            put("DBusername", streamDBUsername);
+            put("DBpassword", streamDBPassword);
+            put("DBstreamdbname", streamdbName);
+            put("DBjournaldbname", journaldbName);
+            put("queryXML", "<index value=\"example\" operation=\"EQUALS\"/>");
+            put("archive.enabled", "true");
+        }
+    };
+
+    @BeforeEach
+    public void setup() {
+        // Start mariadb testcontainer with timezone set to America/New_York (UTC-4). Also creates a second streamdb database inside the container alongside the default journaldb.
+        mariadb = Assertions
+                .assertDoesNotThrow(() -> new MariaDBContainer<>(DockerImageName.parse("mariadb:10.5")).withPrivilegedMode(false).withUsername(streamDBUsername).withPassword(streamDBPassword).withCommand("--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci", "--default-time-zone=" + zoneId.getId()).withDatabaseName(journaldbName).withCopyFileToContainer(MountableFile.forClasspathResource("CREATE_STREAMDB_DB.sql"), "/docker-entrypoint-initdb.d/"));
+        mariadb.start();
+        connection = Assertions
+                .assertDoesNotThrow(
+                        () -> DriverManager
+                                .getConnection(mariadb.getJdbcUrl(), mariadb.getUsername(), mariadb.getPassword())
+                );
+        // streamdb and journaldb is populated with test data during MariaDBContainer startup using CREATE_STREAMDB_DB.sql. Logfile table of journaldb is left empty for tests to populate it.
+    }
+
+    @AfterEach
+    public void cleanup() {
+        mariadb.stop();
+    }
+
+    private LogfileRecord logfileRecordForEpoch(long epoch, boolean hasNullEpochColumns) {
+        Instant instant = Instant.ofEpochSecond(epoch);
+        ZonedDateTime zonedDateTime = instant.atZone(zoneId);
+        int year = zonedDateTime.getYear();
+        // format 0 in front of string if 1-9
+        String month = String.format("%02d", zonedDateTime.getMonthValue());
+        String day = String.format("%02d", zonedDateTime.getDayOfMonth());
+        String hour = String.format("%02d", zonedDateTime.getHour());
+
+        String filename = "example.log-@" + epoch + "-" + year + month + day + hour + ".rfc5424.log.gz";
+        String path = year + "/" + month + "-" + day + "/example.tg.dev.test/example/" + filename;
+        LogfileRecord logfileRecord = new LogfileRecord(
+                ULong.valueOf(epoch),
+                Date.valueOf(zonedDateTime.toLocalDate()),
+                Date.valueOf(zonedDateTime.plusYears(1).toLocalDate()),
+                UShort.valueOf(1),
+                path,
+                null,
+                UShort.valueOf(1),
+                filename,
+                new Timestamp(epoch),
+                ULong.valueOf(120L),
+                "sha256 checksum 1",
+                "archive tag 1",
+                "oldExample",
+                UShort.valueOf(2),
+                UShort.valueOf(1),
+                ULong.valueOf(390L),
+                ULong.valueOf(epoch),
+                ULong.valueOf(epoch + (365 * 24 * 3600)),
+                ULong.valueOf(epoch),
+                null,
+                ULong.valueOf(1),
+                null
+        );
+
+        LogfileRecord nullEpochRecord = new LogfileRecord(
+                ULong.valueOf(epoch),
+                Date.valueOf(zonedDateTime.toLocalDate()),
+                Date.valueOf(zonedDateTime.plusYears(1).toLocalDate()),
+                UShort.valueOf(1),
+                path,
+                null,
+                UShort.valueOf(1),
+                filename,
+                new Timestamp(epoch),
+                ULong.valueOf(120L),
+                "sha256 checksum 1",
+                "archive tag 1",
+                "oldExample",
+                UShort.valueOf(2),
+                UShort.valueOf(1),
+                ULong.valueOf(390L),
+                null,
+                null,
+                null,
+                null,
+                ULong.valueOf(1),
+                null
+        );
+
+        if (hasNullEpochColumns) {
+            return nullEpochRecord;
+        }
+        return logfileRecord;
+    }
+
+    @Test
+    public void earliestConditionDefaultTimezoneQueryAllTest() {
+        // Add test data to logfile table in journaldb.
+        final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
+        Instant instant = Instant.ofEpochSecond(1696471200L);
+        ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
+        ZonedDateTime instantPlusHour = instantZonedDateTime.plusHours(1);
+        LogfileRecord logfileRecord = logfileRecordForEpoch(instantZonedDateTime.toEpochSecond(), true);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
+        LogfileRecord logfileRecord2 = logfileRecordForEpoch(instantPlusHour.toEpochSecond(), true);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
+
+        final Map<String, String> opts = this.opts;
+        opts.put("DBurl", mariadb.getJdbcUrl());
+        opts
+                .put(
+                        "queryXML",
+                        "<AND><AND><index value=\"example\" operation=\"EQUALS\"/></AND><earliest value=\""
+                                + instantZonedDateTime.toEpochSecond() + "\" operation=\"GE\"/></AND>"
+                );
+        final Config config = new Config(opts);
+        Assertions.assertDoesNotThrow(() -> {
+            try (final StreamDBClient sdc = new StreamDBClient(config)) {
+                // Pull the records from a specific logdate to the slicetable for further processing.
+                int rows = sdc.pullToSliceTable(Date.valueOf(instantZonedDateTime.toLocalDate()));
+                Assertions.assertEquals(2, rows);
+
+                // find the earliest row and assert that it has correct offset/logtime value
+                Assertions.assertFalse(sdc.getNextHourAndSizeFromSliceTable(0L).isStub);
+                Assertions
+                        .assertEquals(instantZonedDateTime.toEpochSecond(), sdc.getNextHourAndSizeFromSliceTable(0L).offset());
+                // find the next row after earliest
+                Assertions
+                        .assertFalse(sdc.getNextHourAndSizeFromSliceTable(instantZonedDateTime.toEpochSecond()).isStub);
+                Assertions
+                        .assertEquals(
+                                instantPlusHour.toEpochSecond(),
+                                sdc.getNextHourAndSizeFromSliceTable(instantZonedDateTime.toEpochSecond()).offset()
+                        );
+            }
+        });
+    }
+
+    @Test
+    public void earliestConditionDefaultTimezoneQuerySingleTest() {
+        // Add test data to logfile table in journaldb.
+        final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
+        Instant instant = Instant.ofEpochSecond(1696471200L);
+        ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
+        ZonedDateTime instantPlusHour = instantZonedDateTime.plusHours(1);
+        LogfileRecord logfileRecord = logfileRecordForEpoch(instantZonedDateTime.toEpochSecond(), true);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
+        LogfileRecord logfileRecord2 = logfileRecordForEpoch(instantPlusHour.toEpochSecond(), true);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
+
+        final Map<String, String> opts = this.opts;
+        opts.put("DBurl", mariadb.getJdbcUrl());
+        opts
+                .put(
+                        "queryXML",
+                        "<AND><AND><index value=\"example\" operation=\"EQUALS\"/></AND><earliest value=\""
+                                + instantPlusHour.toEpochSecond() + "\" operation=\"GE\"/></AND>"
+                );
+        final Config config = new Config(opts);
+        Assertions.assertDoesNotThrow(() -> {
+            try (final StreamDBClient sdc = new StreamDBClient(config)) {
+                // Pull the records from a specific logdate to the slicetable for further processing.
+                int rows = sdc.pullToSliceTable(Date.valueOf(instantZonedDateTime.toLocalDate()));
+                Assertions.assertEquals(1, rows);
+
+                // find the earliest row and assert that it has correct offset/logtime value
+                Assertions.assertFalse(sdc.getNextHourAndSizeFromSliceTable(0L).isStub);
+                Assertions
+                        .assertEquals(instantPlusHour.toEpochSecond(), sdc.getNextHourAndSizeFromSliceTable(0L).offset());
+            }
+        });
+    }
+
+}

--- a/src/test/java/com/teragrep/pth_06/planner/EarliestConditionQueryTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/EarliestConditionQueryTest.java
@@ -94,7 +94,7 @@ class EarliestConditionQueryTest {
 
     @BeforeEach
     public void setup() {
-        // Start mariadb testcontainer with timezone set to America/New_York (UTC-4). Also creates a second streamdb database inside the container alongside the default journaldb.
+        // Start mariadb testcontainer with timezone set to system default. Also creates a second streamdb database inside the container alongside the default journaldb.
         mariadb = Assertions
                 .assertDoesNotThrow(() -> new MariaDBContainer<>(DockerImageName.parse("mariadb:10.5")).withPrivilegedMode(false).withUsername(streamDBUsername).withPassword(streamDBPassword).withCommand("--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci", "--default-time-zone=" + zoneId.getId()).withDatabaseName(journaldbName).withCopyFileToContainer(MountableFile.forClasspathResource("CREATE_STREAMDB_DB.sql"), "/docker-entrypoint-initdb.d/"));
         mariadb.start();

--- a/src/test/java/com/teragrep/pth_06/planner/LatestConditionQueryTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/LatestConditionQueryTest.java
@@ -94,7 +94,7 @@ class LatestConditionQueryTest {
 
     @BeforeEach
     public void setup() {
-        // Start mariadb testcontainer with timezone set to America/New_York (UTC-4). Also creates a second streamdb database inside the container alongside the default journaldb.
+        // Start mariadb testcontainer with timezone set to system default. Also creates a second streamdb database inside the container alongside the default journaldb.
         mariadb = Assertions
                 .assertDoesNotThrow(() -> new MariaDBContainer<>(DockerImageName.parse("mariadb:10.5")).withPrivilegedMode(false).withUsername(streamDBUsername).withPassword(streamDBPassword).withCommand("--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci", "--default-time-zone=" + zoneId.getId()).withDatabaseName(journaldbName).withCopyFileToContainer(MountableFile.forClasspathResource("CREATE_STREAMDB_DB.sql"), "/docker-entrypoint-initdb.d/"));
         mariadb.start();

--- a/src/test/java/com/teragrep/pth_06/planner/LatestConditionQueryTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/LatestConditionQueryTest.java
@@ -1,0 +1,259 @@
+/*
+ * Teragrep Archive Datasource (pth_06)
+ * Copyright (C) 2021-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.pth_06.planner;
+
+import com.teragrep.pth_06.config.Config;
+import com.teragrep.pth_06.jooq.generated.journaldb.tables.records.LogfileRecord;
+import org.jooq.*;
+import org.jooq.impl.DSL;
+import org.jooq.types.ULong;
+import org.jooq.types.UShort;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+import java.sql.*;
+import java.time.*;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.teragrep.pth_06.jooq.generated.journaldb.Journaldb.JOURNALDB;
+
+class LatestConditionQueryTest {
+
+    private MariaDBContainer<?> mariadb;
+    private Connection connection;
+    // Set the zoneId to system default
+    private final ZoneId zoneId = ZoneId.systemDefault();
+    private final String streamDBUsername = "streamdb";
+    private final String streamDBPassword = "streamdb_pass";
+
+    private final String streamdbName = "streamdb";
+    private final String journaldbName = "journaldb";
+    private final Map<String, String> opts = new HashMap<String, String>() {
+
+        {
+            put("S3endPoint", "mock");
+            put("S3identity", "mock");
+            put("S3credential", "mock");
+            put("DBusername", streamDBUsername);
+            put("DBpassword", streamDBPassword);
+            put("DBstreamdbname", streamdbName);
+            put("DBjournaldbname", journaldbName);
+            put("queryXML", "<index value=\"example\" operation=\"EQUALS\"/>");
+            put("archive.enabled", "true");
+        }
+    };
+
+    @BeforeEach
+    public void setup() {
+        // Start mariadb testcontainer with timezone set to America/New_York (UTC-4). Also creates a second streamdb database inside the container alongside the default journaldb.
+        mariadb = Assertions
+                .assertDoesNotThrow(() -> new MariaDBContainer<>(DockerImageName.parse("mariadb:10.5")).withPrivilegedMode(false).withUsername(streamDBUsername).withPassword(streamDBPassword).withCommand("--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci", "--default-time-zone=" + zoneId.getId()).withDatabaseName(journaldbName).withCopyFileToContainer(MountableFile.forClasspathResource("CREATE_STREAMDB_DB.sql"), "/docker-entrypoint-initdb.d/"));
+        mariadb.start();
+        connection = Assertions
+                .assertDoesNotThrow(
+                        () -> DriverManager
+                                .getConnection(mariadb.getJdbcUrl(), mariadb.getUsername(), mariadb.getPassword())
+                );
+        // streamdb and journaldb is populated with test data during MariaDBContainer startup using CREATE_STREAMDB_DB.sql. Logfile table of journaldb is left empty for tests to populate it.
+    }
+
+    @AfterEach
+    public void cleanup() {
+        mariadb.stop();
+    }
+
+    private LogfileRecord logfileRecordForEpoch(long epoch, boolean hasNullEpochColumns) {
+        Instant instant = Instant.ofEpochSecond(epoch);
+        ZonedDateTime zonedDateTime = instant.atZone(zoneId);
+        int year = zonedDateTime.getYear();
+        // format 0 in front of string if 1-9
+        String month = String.format("%02d", zonedDateTime.getMonthValue());
+        String day = String.format("%02d", zonedDateTime.getDayOfMonth());
+        String hour = String.format("%02d", zonedDateTime.getHour());
+
+        String filename = "example.log-@" + epoch + "-" + year + month + day + hour + ".rfc5424.log.gz";
+        String path = year + "/" + month + "-" + day + "/example.tg.dev.test/example/" + filename;
+        LogfileRecord logfileRecord = new LogfileRecord(
+                ULong.valueOf(epoch),
+                Date.valueOf(zonedDateTime.toLocalDate()),
+                Date.valueOf(zonedDateTime.plusYears(1).toLocalDate()),
+                UShort.valueOf(1),
+                path,
+                null,
+                UShort.valueOf(1),
+                filename,
+                new Timestamp(epoch),
+                ULong.valueOf(120L),
+                "sha256 checksum 1",
+                "archive tag 1",
+                "oldExample",
+                UShort.valueOf(2),
+                UShort.valueOf(1),
+                ULong.valueOf(390L),
+                ULong.valueOf(epoch),
+                ULong.valueOf(epoch + (365 * 24 * 3600)),
+                ULong.valueOf(epoch),
+                null,
+                ULong.valueOf(1),
+                null
+        );
+
+        LogfileRecord nullEpochRecord = new LogfileRecord(
+                ULong.valueOf(epoch),
+                Date.valueOf(zonedDateTime.toLocalDate()),
+                Date.valueOf(zonedDateTime.plusYears(1).toLocalDate()),
+                UShort.valueOf(1),
+                path,
+                null,
+                UShort.valueOf(1),
+                filename,
+                new Timestamp(epoch),
+                ULong.valueOf(120L),
+                "sha256 checksum 1",
+                "archive tag 1",
+                "oldExample",
+                UShort.valueOf(2),
+                UShort.valueOf(1),
+                ULong.valueOf(390L),
+                null,
+                null,
+                null,
+                null,
+                ULong.valueOf(1),
+                null
+        );
+
+        if (hasNullEpochColumns) {
+            return nullEpochRecord;
+        }
+        return logfileRecord;
+    }
+
+    @Test
+    public void latestConditionDefaultTimezoneQueryAllTest() {
+        // Add test data to logfile table in journaldb.
+        final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
+        Instant instant = Instant.ofEpochSecond(1696438800L);
+        ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
+        ZonedDateTime instantPlusHour = instantZonedDateTime.plusHours(1);
+        LogfileRecord logfileRecord = logfileRecordForEpoch(instantZonedDateTime.toEpochSecond(), true);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
+        LogfileRecord logfileRecord2 = logfileRecordForEpoch(instantPlusHour.toEpochSecond(), true);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
+
+        final Map<String, String> opts = this.opts;
+        opts.put("DBurl", mariadb.getJdbcUrl());
+        opts
+                .put(
+                        "queryXML",
+                        "<AND><AND><index value=\"example\" operation=\"EQUALS\"/></AND><latest value=\""
+                                + instantPlusHour.toEpochSecond() + "\" operation=\"LE\"/></AND>"
+                );
+        final Config config = new Config(opts);
+        Assertions.assertDoesNotThrow(() -> {
+            try (final StreamDBClient sdc = new StreamDBClient(config)) {
+                // Pull the records from a specific logdate to the slicetable for further processing.
+                int rows = sdc.pullToSliceTable(Date.valueOf(instantZonedDateTime.toLocalDate()));
+                Assertions.assertEquals(2, rows);
+
+                // find the earliest row and assert that it has correct offset/logtime value
+                Assertions.assertFalse(sdc.getNextHourAndSizeFromSliceTable(0L).isStub);
+                Assertions
+                        .assertEquals(instantZonedDateTime.toEpochSecond(), sdc.getNextHourAndSizeFromSliceTable(0L).offset());
+                // find the next row after earliest
+                Assertions
+                        .assertFalse(sdc.getNextHourAndSizeFromSliceTable(instantZonedDateTime.toEpochSecond()).isStub);
+                Assertions
+                        .assertEquals(
+                                instantPlusHour.toEpochSecond(),
+                                sdc.getNextHourAndSizeFromSliceTable(instantZonedDateTime.toEpochSecond()).offset()
+                        );
+            }
+        });
+    }
+
+    @Test
+    public void latestConditionDefaultTimezoneQuerySingleTest() {
+        // Add test data to logfile table in journaldb.
+        final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
+        Instant instant = Instant.ofEpochSecond(1696438800L);
+        ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
+        ZonedDateTime instantPlusHour = instantZonedDateTime.plusHours(1);
+        LogfileRecord logfileRecord = logfileRecordForEpoch(instantZonedDateTime.toEpochSecond(), true);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
+        LogfileRecord logfileRecord2 = logfileRecordForEpoch(instantPlusHour.toEpochSecond(), true);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
+
+        final Map<String, String> opts = this.opts;
+        opts.put("DBurl", mariadb.getJdbcUrl());
+        opts
+                .put(
+                        "queryXML",
+                        "<AND><AND><index value=\"example\" operation=\"EQUALS\"/></AND><latest value=\""
+                                + instantZonedDateTime.toEpochSecond() + "\" operation=\"LE\"/></AND>"
+                );
+        final Config config = new Config(opts);
+        Assertions.assertDoesNotThrow(() -> {
+            try (final StreamDBClient sdc = new StreamDBClient(config)) {
+                // Pull the records from a specific logdate to the slicetable for further processing.
+                int rows = sdc.pullToSliceTable(Date.valueOf(instantZonedDateTime.toLocalDate()));
+                Assertions.assertEquals(1, rows);
+
+                // find the earliest row and assert that it has correct offset/logtime value
+                Assertions.assertFalse(sdc.getNextHourAndSizeFromSliceTable(0L).isStub);
+                Assertions
+                        .assertEquals(instantZonedDateTime.toEpochSecond(), sdc.getNextHourAndSizeFromSliceTable(0L).offset());
+            }
+        });
+    }
+
+}

--- a/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
@@ -630,6 +630,52 @@ class StreamDBClientTest {
     }
 
     @Test
+    public void earliestConditionQueryTest() {
+        // Add test data to logfile table in journaldb.
+        final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
+        // Inserting logfile with logtime of 2023-10-04 22:00 UTC-4.
+        Instant instant = Instant.ofEpochSecond(1696471200L);
+        ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
+        ZonedDateTime instantPlusHour = instantZonedDateTime.plusHours(1);
+        LogfileRecord logfileRecord = logfileRecordForEpoch(instantZonedDateTime.toEpochSecond(), true);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
+        // Inserting logfile with logtime of 2023-10-04 23:00 UTC-4.
+        LogfileRecord logfileRecord2 = logfileRecordForEpoch(instantPlusHour.toEpochSecond(), true);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
+
+        // Set EarliestCondition to an epoch that represents 2023-10-04 19:00 UTC-4, for pullToSliceTable() to ignore records with logtime of 2023-10-04 19:00 UTC-4 or older.
+        final Map<String, String> opts = this.opts;
+        opts.put("DBurl", mariadb.getJdbcUrl());
+        opts
+                .put(
+                        "queryXML",
+                        "<AND><AND><index value=\"example\" operation=\"EQUALS\"/></AND><earliest value=\""
+                                + instantZonedDateTime.minusHours(3).toEpochSecond() + "\" operation=\"GE\"/></AND>"
+                );
+        final Config config = new Config(opts);
+        Assertions.assertDoesNotThrow(() -> {
+            try (final StreamDBClient sdc = new StreamDBClient(config)) {
+                // Pull the records from a specific logdate to the slicetable for further processing.
+                int rows = sdc.pullToSliceTable(Date.valueOf(instantZonedDateTime.toLocalDate()));
+                Assertions.assertEquals(2, rows);
+
+                // find the earliest row and assert that it has correct offset/logtime value
+                Assertions.assertFalse(sdc.getNextHourAndSizeFromSliceTable(0L).isStub);
+                Assertions
+                        .assertEquals(instantZonedDateTime.toEpochSecond(), sdc.getNextHourAndSizeFromSliceTable(0L).offset());
+                // find the next row after earliest
+                Assertions
+                        .assertFalse(sdc.getNextHourAndSizeFromSliceTable(instantZonedDateTime.toEpochSecond()).isStub);
+                Assertions
+                        .assertEquals(
+                                instantPlusHour.toEpochSecond(),
+                                sdc.getNextHourAndSizeFromSliceTable(instantZonedDateTime.toEpochSecond()).offset()
+                        );
+            }
+        });
+    }
+
+    @Test
     public void equalsHashCodeContractTest() {
         EqualsVerifier
                 .forClass(StreamDBClient.class)

--- a/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
@@ -121,7 +121,7 @@ class StreamDBClientTest {
         String day = String.format("%02d", zonedDateTime.getDayOfMonth());
         String hour = String.format("%02d", zonedDateTime.getHour());
 
-        String filename = "example.log-@" + epoch + "-" + year + month + day + hour + ".log.gz";
+        String filename = "example.log-@" + epoch + "-" + year + month + day + hour + ".rfc5424.log.gz";
         String path = year + "/" + month + "-" + day + "/example.tg.dev.test/example/" + filename;
         LogfileRecord logfileRecord = new LogfileRecord(
                 ULong.valueOf(epoch),

--- a/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
@@ -53,10 +53,7 @@ import org.jooq.*;
 import org.jooq.impl.DSL;
 import org.jooq.types.ULong;
 import org.jooq.types.UShort;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
@@ -629,6 +626,9 @@ class StreamDBClientTest {
         Assertions.assertTrue(nextHourAndSizeFromSliceTable.isStub);
     }
 
+    @Disabled(
+        "EarliectCondition will not work properly if MariaDB is in a lower timezone than the JVM, see issue #355 for details."
+    )
     @Test
     public void earliestConditionQueryTest() {
         // Add test data to logfile table in journaldb.
@@ -643,14 +643,63 @@ class StreamDBClientTest {
         LogfileRecord logfileRecord2 = logfileRecordForEpoch(instantPlusHour.toEpochSecond(), true);
         ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
 
-        // Set EarliestCondition to an epoch that represents 2023-10-04 19:00 UTC-4, for pullToSliceTable() to ignore records with logtime of 2023-10-04 19:00 UTC-4 or older.
+        // Set EarliestCondition to an epoch that represents 2023-10-04 22:00 UTC-4, for pullToSliceTable() to ignore records with logtime older than 2023-10-04 22:00 UTC-4.
         final Map<String, String> opts = this.opts;
         opts.put("DBurl", mariadb.getJdbcUrl());
         opts
                 .put(
                         "queryXML",
                         "<AND><AND><index value=\"example\" operation=\"EQUALS\"/></AND><earliest value=\""
-                                + instantZonedDateTime.minusHours(3).toEpochSecond() + "\" operation=\"GE\"/></AND>"
+                                + instantZonedDateTime.toEpochSecond() + "\" operation=\"GE\"/></AND>"
+                );
+        final Config config = new Config(opts);
+        Assertions.assertDoesNotThrow(() -> {
+            try (final StreamDBClient sdc = new StreamDBClient(config)) {
+                // Pull the records from a specific logdate to the slicetable for further processing.
+                int rows = sdc.pullToSliceTable(Date.valueOf(instantZonedDateTime.toLocalDate()));
+                Assertions.assertEquals(2, rows);
+
+                // find the earliest row and assert that it has correct offset/logtime value
+                Assertions.assertFalse(sdc.getNextHourAndSizeFromSliceTable(0L).isStub);
+                Assertions
+                        .assertEquals(instantZonedDateTime.toEpochSecond(), sdc.getNextHourAndSizeFromSliceTable(0L).offset());
+                // find the next row after earliest
+                Assertions
+                        .assertFalse(sdc.getNextHourAndSizeFromSliceTable(instantZonedDateTime.toEpochSecond()).isStub);
+                Assertions
+                        .assertEquals(
+                                instantPlusHour.toEpochSecond(),
+                                sdc.getNextHourAndSizeFromSliceTable(instantZonedDateTime.toEpochSecond()).offset()
+                        );
+            }
+        });
+    }
+
+    @Disabled(
+        "LatestCondition will not work properly if MariaDB is in a higher timezone than the JVM, see issue #355 for details."
+    )
+    @Test
+    public void latestConditionQueryTest() {
+        // Add test data to logfile table in journaldb.
+        final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
+        // Inserting logfile with logtime of 2023-10-04 13:00 UTC-4.
+        Instant instant = Instant.ofEpochSecond(1696438800L);
+        ZonedDateTime instantZonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
+        ZonedDateTime instantPlusHour = instantZonedDateTime.plusHours(1);
+        LogfileRecord logfileRecord = logfileRecordForEpoch(instantZonedDateTime.toEpochSecond(), true);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord).execute();
+        // Inserting logfile with logtime of 2023-10-04 14:00 UTC-4.
+        LogfileRecord logfileRecord2 = logfileRecordForEpoch(instantPlusHour.toEpochSecond(), true);
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecord2).execute();
+
+        // Set LatestCondition to an epoch that represents 2023-10-04 14:00 UTC-4, for pullToSliceTable() to ignore records with logtime newer than 2023-10-04 14:00 UTC-4.
+        final Map<String, String> opts = this.opts;
+        opts.put("DBurl", mariadb.getJdbcUrl());
+        opts
+                .put(
+                        "queryXML",
+                        "<AND><AND><index value=\"example\" operation=\"EQUALS\"/></AND><latest value=\""
+                                + instantPlusHour.toEpochSecond() + "\" operation=\"LE\"/></AND>"
                 );
         final Config config = new Config(opts);
         Assertions.assertDoesNotThrow(() -> {

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
@@ -61,7 +61,7 @@ public class EarliestConditionTest {
     @Test
     public void conditionTest() {
         String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" >= date '1970-01-01'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 0)\n"
+                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 0)\n"
                 + ")";
         Condition elementCondition = new EarliestCondition("1000").condition();
         Assertions.assertEquals(e, elementCondition.toString());

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
@@ -61,7 +61,7 @@ public class LatestConditionTest {
     @Test
     public void conditionTest() {
         String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" <= date '1970-01-01'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1000)\n"
+                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1000)\n"
                 + ")";
         Condition elementCondition = new LatestCondition("1000").condition();
         Assertions.assertEquals(e, elementCondition.toString());
@@ -70,7 +70,7 @@ public class LatestConditionTest {
     @Test
     public void conditionUpdatedTest() {
         String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" <= date '2000-01-01'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 946720800)\n"
+                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 946720800)\n"
                 + ")";
         Condition elementCondition = new LatestCondition("946720800").condition();
         Assertions.assertEquals(e, elementCondition.toString());

--- a/src/test/java/com/teragrep/pth_06/walker/ConditionWalkerTest.java
+++ b/src/test/java/com/teragrep/pth_06/walker/ConditionWalkerTest.java
@@ -252,9 +252,9 @@ public class ConditionWalkerTest {
         String e = "(\n" + "  \"bloomdb\".\"pattern_test_ip\".\"filter\" is null\n"
                 + "  and \"getArchivedObjects_filter_table\".\"directory\" like 'haproxy'\n"
                 + "  and \"journaldb\".\"logfile\".\"logdate\" >= date '2022-01-26'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1643205600)\n"
+                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1643205600)\n"
                 + "  and \"journaldb\".\"logfile\".\"logdate\" <= date '2024-10-20'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1729435021)\n"
+                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1729435021)\n"
                 + ")";
         Condition cond = Assertions.assertDoesNotThrow(() -> walker.fromString(q, false));
         Assertions.assertEquals(e, cond.toString());
@@ -298,9 +298,9 @@ public class ConditionWalkerTest {
         String q = "<AND><index operation=\"EQUALS\" value=\"search_bench\"/><AND><AND><AND><earliest operation=\"GE\" value=\"1643207821\"/><latest operation=\"LE\" value=\"1729435021\"/></AND><indexstatement operation=\"EQUALS\" value=\"192.168.1.1\"/></AND><indexstatement operation=\"EQUALS\" value=\"192.000.1.1\"/></AND></AND>";
         String e = "(\n" + "  \"getArchivedObjects_filter_table\".\"directory\" like 'search_bench'\n"
                 + "  and \"journaldb\".\"logfile\".\"logdate\" >= date '2022-01-26'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1643205600)\n"
+                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1643205600)\n"
                 + "  and \"journaldb\".\"logfile\".\"logdate\" <= date '2024-10-20'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1729435021)\n"
+                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1729435021)\n"
                 + "  and (\n" + "    (\n" + "      bloommatch(\n" + "        (\n"
                 + "          select \"term_0_pattern_test_ip\".\"filter\"\n"
                 + "          from \"term_0_pattern_test_ip\"\n" + "          where (\n" + "            term_id = 0\n"

--- a/src/test/java/com/teragrep/pth_06/walker/XmlWalkerTest.java
+++ b/src/test/java/com/teragrep/pth_06/walker/XmlWalkerTest.java
@@ -188,7 +188,7 @@ public class XmlWalkerTest {
                 + "  or (\n" + "    true\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'firewall.example.com'\n"
                 + "    and \"journaldb\".\"logfile\".\"logdate\" >= date '2021-01-26'\n"
-                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1611655200)\n"
+                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1611655200)\n"
                 + "  )\n" + ")";
         result = conditionWalker.fromString(q, false).toString();
         assertEquals(e, result);
@@ -204,9 +204,9 @@ public class XmlWalkerTest {
                 + "  or (\n" + "    true\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'firewall.example.com'\n"
                 + "    and \"journaldb\".\"logfile\".\"logdate\" >= date '2021-01-26'\n"
-                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1611655200)\n"
+                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1611655200)\n"
                 + "    and \"journaldb\".\"logfile\".\"logdate\" <= date '2021-04-26'\n"
-                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1619437701)\n"
+                + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1619437701)\n"
                 + "  )\n" + ")";
         Condition cond = conditionWalker.fromString(q, false);
         if (cond != null) {
@@ -226,9 +226,9 @@ public class XmlWalkerTest {
                 + "  and \"getArchivedObjects_filter_table\".\"directory\" like 'cpu'\n"
                 + "  and \"getArchivedObjects_filter_table\".\"stream\" like 'log:cpu:0'\n"
                 + "  and \"journaldb\".\"logfile\".\"logdate\" >= date '1970-01-01'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 0)\n"
+                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 0)\n"
                 + "  and \"journaldb\".\"logfile\".\"logdate\" <= date '2030-01-01'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1893491420)\n"
+                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1893491420)\n"
                 + ")";
         Condition cond = conditionWalker.fromString(q, false);
         result = cond.toString();


### PR DESCRIPTION
## Description

Aims to fix issue #353 by adding `.rfc5424` as an optional substring in the regex used by EarliestCondition and LatestCondition classes. The optional `.log` substring is already handled similarly in the regex.

Includes:
- Changes to EarliestCondition and LatestCondition classes
- Updated all the tests that were affected by the change.
- Added new tests that use the system default timezone for MariaDB.

The regex change will only take in account the new `.rfc5424` substring, if any other kind of object_format denoting string is used then it should also be added to the regex as optional substring.

Resolves #353 

## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

#### General

- [ ] I have checked that my test files and functions have meaningful names.
- [ ] I have checked that each test tests only a single behavior.
- [ ] I have done happy tests.
- [ ] I have tested only my own code.
- [ ] I have tested at least all public methods. 

#### Assertions

- [ ] I have checked that my tests use assertions and not runtime overhead.
- [ ] I have checked that my tests end in assertions.
- [ ] I have checked that there is no comparison statements in assertions.
- [ ] I have checked that assertions are in tests and not in helper functions.
- [ ] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [ ] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [ ] I have tested algorithms and anything else with the possibility of unbound growth.
- [ ] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [ ] I have checked that all test files are standalone.
- [ ] I have checked that all test-specific fake objects and classes are in the test directory.
- [ ] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [ ] I have checked that my tests do not contain non-generic information.
- [ ] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [ ] I have checked that my tests do not use throws for exceptions.
- [ ] I have checked that my tests do not use try-catch statements.
- [ ] I have checked that my tests do not use if-else statements.

#### Java

- [ ] I have checked that my tests for Java uses JUnit library.
- [ ] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [ ] I have only tested public behavior and not private implementation details.
- [ ] I have checked that my tests are not (partially) commented out.
- [ ] I have checked that hand-crafted variables in assertions are used accordingly.
- [ ] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [ ] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [ ] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [ ] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [ ] I have checked that my code follows metrics set in Procedure: Object Quality.
- [ ] I have checked that my code does not have any NULL values.
- [ ] I have checked my code does not contain FIXME or TODO comments.  
