### PR TITLE
[bugfix] epoch migration correctly handles non gzip files

### DIFF
--- a/src/main/java/com/teragrep/pth_06/task/s3/EpochMigrationRowConverter.java
+++ b/src/main/java/com/teragrep/pth_06/task/s3/EpochMigrationRowConverter.java
@@ -250,13 +250,14 @@ public final class EpochMigrationRowConverter implements RowConverter {
         if (objectContent != null) {
             LOGGER.info("S3FileHandler.close() on log <{}> read attempted <{}>", logName, readAttempted);
             releaseObjectContentStream();
-        } else {
+        }
+        else {
             LOGGER.info("S3FileHandler.close() finished for log <{}> no active stream to close", logName);
         }
     }
 
     private void releaseObjectContentStream() throws IOException {
-        if(this.objectContent != null) {
+        if (this.objectContent != null) {
             // abort() called before close() to avoid from reading the object fully before releasing its attached http connection
             objectContent.abort();
             objectContent.close();

--- a/src/main/java/com/teragrep/pth_06/task/s3/EpochMigrationRowConverter.java
+++ b/src/main/java/com/teragrep/pth_06/task/s3/EpochMigrationRowConverter.java
@@ -145,6 +145,8 @@ public final class EpochMigrationRowConverter implements RowConverter {
                 final BufferedInputStream bufferedInputStream = new BufferedInputStream(objectContent, 256 * 1024);
                 final GZIPInputStream gz = new GZIPInputStream(bufferedInputStream);
                 rfc5424Frame.load(gz);
+                LOGGER.trace("S3FileHandler.open() Initialized result set with element lists");
+                LOGGER.info("S3FileHandler.open() Initialized parser for <[{}]>", logName);
             }
             catch (final ZipException zipException) {
                 LOGGER
@@ -152,16 +154,8 @@ public final class EpochMigrationRowConverter implements RowConverter {
                                 "ZipException at object: <[{}]>/<[{}]> - exception message: <{}>", bucket, path,
                                 zipException.getMessage()
                         );
-                // cannot read non gzip format file, closing the stream
-                if (this.objectContent != null) {
-                    LOGGER.info("Closing S3ObjectInputStream for the non GZIP format file");
-                    objectContent.abort();
-                    objectContent.close();
-                    objectContent = null;
-                }
+                releaseObjectContentStream();
             }
-            LOGGER.trace("S3FileHandler.open() Initialized result set with element lists");
-            LOGGER.info("S3FileHandler.open() Initialized parser for <[{}]>", logName);
         }
         catch (final AmazonServiceException amazonServiceException) {
             if (403 == amazonServiceException.getStatusCode()) {
@@ -253,11 +247,20 @@ public final class EpochMigrationRowConverter implements RowConverter {
     @Override
     public void close() throws IOException {
         final String logName = bucket + "/" + path;
-        LOGGER.info("S3FileHandler.close() on log <{}> read attempted <{}>", logName, readAttempted);
         if (objectContent != null) {
+            LOGGER.info("S3FileHandler.close() on log <{}> read attempted <{}>", logName, readAttempted);
+            releaseObjectContentStream();
+        } else {
+            LOGGER.info("S3FileHandler.close() finished for log <{}> no active stream to close", logName);
+        }
+    }
+
+    private void releaseObjectContentStream() throws IOException {
+        if(this.objectContent != null) {
             // abort() called before close() to avoid from reading the object fully before releasing its attached http connection
             objectContent.abort();
             objectContent.close();
+            objectContent = null;
         }
     }
 }

--- a/src/main/java/com/teragrep/pth_06/task/s3/EpochMigrationRowConverter.java
+++ b/src/main/java/com/teragrep/pth_06/task/s3/EpochMigrationRowConverter.java
@@ -140,22 +140,12 @@ public final class EpochMigrationRowConverter implements RowConverter {
                         );
             }
             this.objectContent = s3object.getObjectContent();
+            final BufferedInputStream bufferedInputStream = new BufferedInputStream(objectContent, 256 * 1024);
+            final GZIPInputStream gz = new GZIPInputStream(bufferedInputStream);
+            rfc5424Frame.load(gz);
+            LOGGER.trace("S3FileHandler.open() Initialized result set with element lists");
+            LOGGER.info("S3FileHandler.open() Initialized parser for <[{}]>", logName);
 
-            try {
-                final BufferedInputStream bufferedInputStream = new BufferedInputStream(objectContent, 256 * 1024);
-                final GZIPInputStream gz = new GZIPInputStream(bufferedInputStream);
-                rfc5424Frame.load(gz);
-                LOGGER.trace("S3FileHandler.open() Initialized result set with element lists");
-                LOGGER.info("S3FileHandler.open() Initialized parser for <[{}]>", logName);
-            }
-            catch (final ZipException zipException) {
-                LOGGER
-                        .error(
-                                "ZipException at object: <[{}]>/<[{}]> - exception message: <{}>", bucket, path,
-                                zipException.getMessage()
-                        );
-                releaseObjectContentStream();
-            }
         }
         catch (final AmazonServiceException amazonServiceException) {
             if (403 == amazonServiceException.getStatusCode()) {
@@ -164,6 +154,14 @@ public final class EpochMigrationRowConverter implements RowConverter {
             else {
                 throw amazonServiceException;
             }
+        }
+        catch (final ZipException zipException) {
+            LOGGER
+                    .error(
+                            "ZipException at object <[{}]>, closing file - message <{}>", logName,
+                            zipException.getMessage()
+                    );
+            close();
         }
     }
 
@@ -249,15 +247,6 @@ public final class EpochMigrationRowConverter implements RowConverter {
         final String logName = bucket + "/" + path;
         if (objectContent != null) {
             LOGGER.info("S3FileHandler.close() on log <{}> read attempted <{}>", logName, readAttempted);
-            releaseObjectContentStream();
-        }
-        else {
-            LOGGER.info("S3FileHandler.close() finished for log <{}> no active stream to close", logName);
-        }
-    }
-
-    private void releaseObjectContentStream() throws IOException {
-        if (this.objectContent != null) {
             // abort() called before close() to avoid from reading the object fully before releasing its attached http connection
             objectContent.abort();
             objectContent.close();

--- a/src/main/java/com/teragrep/pth_06/task/s3/EpochMigrationRowConverter.java
+++ b/src/main/java/com/teragrep/pth_06/task/s3/EpochMigrationRowConverter.java
@@ -63,6 +63,7 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipException;
 
 public final class EpochMigrationRowConverter implements RowConverter {
 
@@ -139,9 +140,26 @@ public final class EpochMigrationRowConverter implements RowConverter {
                         );
             }
             this.objectContent = s3object.getObjectContent();
-            final BufferedInputStream bufferedInputStream = new BufferedInputStream(objectContent, 256 * 1024);
-            final GZIPInputStream gz = new GZIPInputStream(bufferedInputStream);
-            rfc5424Frame.load(gz);
+
+            try {
+                final BufferedInputStream bufferedInputStream = new BufferedInputStream(objectContent, 256 * 1024);
+                final GZIPInputStream gz = new GZIPInputStream(bufferedInputStream);
+                rfc5424Frame.load(gz);
+            }
+            catch (final ZipException zipException) {
+                LOGGER
+                        .error(
+                                "ZipException at object: <[{}]>/<[{}]> - exception message: <{}>", bucket, path,
+                                zipException.getMessage()
+                        );
+                // cannot read non gzip format file, closing the stream
+                if (this.objectContent != null) {
+                    LOGGER.info("Closing S3ObjectInputStream for the non GZIP format file");
+                    objectContent.abort();
+                    objectContent.close();
+                    objectContent = null;
+                }
+            }
             LOGGER.trace("S3FileHandler.open() Initialized result set with element lists");
             LOGGER.info("S3FileHandler.open() Initialized parser for <[{}]>", logName);
         }

--- a/src/test/java/com/teragrep/pth_06/task/s3/EpochMigrationRowConverterTest.java
+++ b/src/test/java/com/teragrep/pth_06/task/s3/EpochMigrationRowConverterTest.java
@@ -171,6 +171,50 @@ public final class EpochMigrationRowConverterTest {
         Assertions.assertDoesNotThrow(rowConverter::close);
     }
 
+    @Test
+    public void testNonGzipFormatFile() {
+        // syslog message content should not be available as the object is unreadable non gzip format
+        final String syslog = "<14>1 2014-06-20T09:14:07.12345+00:00 host01 systemd DEA MSG-01 [sd_one@48577 id_one=\"eno\" id_two=\"owt\"][sd_two@48577 id_three=\"eerht\" id_four=\"ruof\"] msg\n";
+        Assertions.assertDoesNotThrow(() -> loadNonGzipFormat(syslog));
+        final RowConverter rowConverter = new EpochMigrationRowConverter(
+                amazonS3,
+                "id",
+                bucket,
+                path,
+                "directory",
+                "stream",
+                "host"
+        );
+        Assertions.assertDoesNotThrow(rowConverter::open);
+        Assertions.assertDoesNotThrow(() -> {
+            Assertions.assertTrue(rowConverter.next(), "first call should succeed");
+        });
+        final InternalRow internalRow = rowConverter.get();
+        long time = internalRow.getLong(0);
+        long expectedEpochSeconds = ZonedDateTime
+                .of(2007, 10, 8, 14, 0, 0, 0, ZoneId.of("Europe/Helsinki"))
+                .toEpochSecond();
+        Assertions
+                .assertEquals(
+                        expectedEpochSeconds * 1000 * 1000, time,
+                        "epoch should be match the one extracted from the file path"
+                );
+
+        final String raw = internalRow.getString(1);
+        final String expectedRaw = "{\"epochMigration\":true,\"format\":\"non-rfc5424\",\"object\":{\"bucket\":\"bucket\",\"path\":\"2007/10-08/epoch/migration/test.logGLOB-2007100814.log.gz\",\"partition\":\"id\"},\"timestamp\":{\"path-extracted\":\"2007-10-08T14:00+03:00[Europe/Helsinki]\",\"path-extracted-precision\":\"hourly\",\"source\":\"object-path\"}}";
+        Assertions
+                .assertEquals(
+                        expectedRaw, raw,
+                        "converted row should match the expected non-rfc5424 row since stream was unreadable"
+                );
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions
+                                .assertFalse(rowConverter.next(), "no more rows available after first read attempt")
+                );
+        Assertions.assertDoesNotThrow(rowConverter::close, "row converter should be closed");
+    }
+
     private void load(final String content) throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (final GZIPOutputStream gzip = new GZIPOutputStream(baos)) {
@@ -178,6 +222,14 @@ public final class EpochMigrationRowConverterTest {
         }
         final ByteArrayInputStream inStream = new ByteArrayInputStream(baos.toByteArray());
         amazonS3.putObject(bucket, path, inStream, null);
+    }
+
+    private void loadNonGzipFormat(final String content) throws IOException {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write(content.getBytes(StandardCharsets.UTF_8));
+        final ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        amazonS3.putObject(bucket, path, bais, null);
+
     }
 
     private void ensureBucketExists() {


### PR DESCRIPTION
## Description

resolves #357 

When the  `EpochMigrationRowConverter` encounters a file that is not in a  gzip format the object stream is ignored and safely closed.
Closing the s3 object stream will trigger the fall back method of extracting the epoch from the object path. This extraction method does not require any access to the s3 object.

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods. 

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [ ] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [ ] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [ ] I have checked that my code follows metrics set in Procedure: Object Quality.
- [ ] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.  
