### PR TITLE
use FROM_UNIXTIME() for earliest and latest condition date conversion

### DIFF
--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/EarliestCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/EarliestCondition.java
@@ -46,9 +46,10 @@
 package com.teragrep.pth_06.planner.walker.conditions;
 
 import org.jooq.Condition;
+import org.jooq.Field;
+import org.jooq.impl.DSL;
 
 import java.sql.Date;
-import java.time.Instant;
 import java.util.Objects;
 
 import static com.teragrep.pth_06.jooq.generated.journaldb.Journaldb.JOURNALDB;
@@ -62,19 +63,11 @@ public final class EarliestCondition implements QueryCondition {
     }
 
     public Condition condition() {
-        // SQL connection uses localTime in the session, so we use unix to come over the conversions
-        // hour based files are being used so earliest needs conversion to the point of the last hour
         final long earliestFromElement = Long.parseLong(value);
+        // hour based files are being used so earliest needs conversion to the point of the last hour
         final long earliestEpochHour = earliestFromElement - earliestFromElement % 3600;
-        final Instant instant = Instant.ofEpochSecond(earliestEpochHour);
-        final java.sql.Date timeQualifier = new Date(instant.toEpochMilli());
-        Condition condition;
-        condition = JOURNALDB.LOGFILE.LOGDATE.greaterOrEqual(timeQualifier);
-        condition = condition
-                .and(
-                        "UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H'))"
-                                + " >= " + instant.getEpochSecond()
-                );
+        // FROM_UNIXTIME() is evaluated by MariaDB using the connection session timezone
+        final Field<Date> fromUnixTimeField = DSL.field("DATE(FROM_UNIXTIME({0}))", Date.class, earliestEpochHour);
         // raw SQL used here since following not supported for mariadb:
         // queryCondition = queryCondition.and(toTimestamp(
         // regexpReplaceAll(JOURNALDB.LOGFILE.PATH, "((^.*\\/.*-)|(\\.log\\.gz.*))", ""),
@@ -83,7 +76,12 @@ public final class EarliestCondition implements QueryCondition {
         // 2021/09-27/sc-99-99-14-244/messages/messages-2021092722.gz.4
         // 2018/04-29/sc-99-99-14-245/f17/f17.logGLOB-2018042900.log.gz
         // NOTE uses literal path
-        return condition;
+        final Condition logtimeCondition = DSL
+                .condition(
+                        "UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= {0}",
+                        earliestEpochHour
+                );
+        return JOURNALDB.LOGFILE.LOGDATE.greaterOrEqual(fromUnixTimeField).and(logtimeCondition);
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_06/planner/walker/conditions/LatestCondition.java
+++ b/src/main/java/com/teragrep/pth_06/planner/walker/conditions/LatestCondition.java
@@ -46,9 +46,10 @@
 package com.teragrep.pth_06.planner.walker.conditions;
 
 import org.jooq.Condition;
+import org.jooq.Field;
+import org.jooq.impl.DSL;
 
 import java.sql.Date;
-import java.time.Instant;
 import java.util.Objects;
 
 import static com.teragrep.pth_06.jooq.generated.journaldb.Journaldb.JOURNALDB;
@@ -62,17 +63,9 @@ public final class LatestCondition implements QueryCondition {
     }
 
     public Condition condition() {
-        // SQL connection uses localTime in the session, so we use unix to come over the conversions
         final long epochSeconds = Long.parseLong(value);
-        final Instant instant = Instant.ofEpochSecond(epochSeconds);
-        final java.sql.Date timeQualifier = new Date(instant.toEpochMilli());
-        Condition condition;
-        condition = JOURNALDB.LOGFILE.LOGDATE.lessOrEqual(timeQualifier);
-        condition = condition
-                .and(
-                        "UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H'))"
-                                + " <= " + instant.getEpochSecond()
-                );
+        // FROM_UNIXTIME() is evaluated by MariaDB using the connection session timezone
+        final Field<Date> fromUnixTimeField = DSL.field("DATE(FROM_UNIXTIME({0}))", Date.class, epochSeconds);
         // raw SQL used here since following not supported for mariadb:
         // queryCondition = queryCondition.and(toTimestamp(
         // regexpReplaceAll(JOURNALDB.LOGFILE.PATH, "((^.*\\/.*-)|(\\.log\\.gz.*))", ""),
@@ -81,7 +74,12 @@ public final class LatestCondition implements QueryCondition {
         // 2021/09-27/sc-99-99-14-244/messages/messages-2021092722.gz.4
         // 2018/04-29/sc-99-99-14-245/f17/f17.logGLOB-2018042900.log.gz
         // NOTE uses literal path
-        return condition;
+        final Condition logtimeCondition = DSL
+                .condition(
+                        "UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= {0}",
+                        epochSeconds
+                );
+        return JOURNALDB.LOGFILE.LOGDATE.lessOrEqual(fromUnixTimeField).and(logtimeCondition);
     }
 
     @Override

--- a/src/test/java/com/teragrep/pth_06/XmlToSqlTest.java
+++ b/src/test/java/com/teragrep/pth_06/XmlToSqlTest.java
@@ -51,7 +51,6 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.Date;
 import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -163,14 +162,14 @@ public class XmlToSqlTest {
         q = "<OR><AND><AND><index value=\"haproxy\" operation=\"NOT_EQUALS\"/><sourcetype value=\"example:haproxy:haproxy\" operation=\"EQUALS\"/></AND><host value=\"loadbalancer.example.com\" operation=\"EQUALS\"/></AND><AND><AND><AND><index value=\"*\" operation=\"EQUALS\"/><host value=\"firewall.example.com\" operation=\"EQUALS\"/></AND><earliest value=\"1611612000\" operation=\"GE\"/></AND><indexstring value=\"Denied\" /></AND></OR>";
         // Add time ranges
         Instant fromTime = Instant.ofEpochSecond(1611612000);
-        Date fromDate = new Date(fromTime.toEpochMilli());
         LOGGER.debug("Journal-DB");
         e = "(\n" + "  (\n" + "    not (\"getArchivedObjects_filter_table\".\"directory\" like 'haproxy')\n"
                 + "    and \"getArchivedObjects_filter_table\".\"stream\" like 'example:haproxy:haproxy'\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'loadbalancer.example.com'\n" + "  )\n"
                 + "  or (\n" + "    true\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'firewall.example.com'\n"
-                + "    and \"journaldb\".\"logfile\".\"logdate\" >= date '" + fromDate + "'\n"
+                + "    and \"journaldb\".\"logfile\".\"logdate\" >= DATE(FROM_UNIXTIME(" + fromTime.getEpochSecond()
+                + "))\n"
                 + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= "
                 + fromTime.getEpochSecond() + ")\n" + "  )\n" + ")";
         result = parser.fromString(q, false).toString();
@@ -188,14 +187,14 @@ public class XmlToSqlTest {
         q = "<OR><AND><AND><index value=\"haproxy\" operation=\"NOT_EQUALS\"/><sourcetype value=\"example:haproxy:haproxy\" operation=\"EQUALS\"/></AND><host value=\"loadbalancer.example.com\" operation=\"EQUALS\"/></AND><AND><AND><AND><index value=\"*\" operation=\"EQUALS\"/><host value=\"firewall.example.com\" operation=\"EQUALS\"/></AND><latest value=\"1611611999\" operation=\"LE\"/></AND><indexstring value=\"Denied\" /></AND></OR>";
         // Add time ranges
         Instant fromTime = Instant.ofEpochSecond(1611611999);
-        Date fromDate = new Date(fromTime.toEpochMilli());
         LOGGER.debug("Journal-DB");
         e = "(\n" + "  (\n" + "    not (\"getArchivedObjects_filter_table\".\"directory\" like 'haproxy')\n"
                 + "    and \"getArchivedObjects_filter_table\".\"stream\" like 'example:haproxy:haproxy'\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'loadbalancer.example.com'\n" + "  )\n"
                 + "  or (\n" + "    true\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'firewall.example.com'\n"
-                + "    and \"journaldb\".\"logfile\".\"logdate\" <= date '" + fromDate + "'\n"
+                + "    and \"journaldb\".\"logfile\".\"logdate\" <= DATE(FROM_UNIXTIME(" + fromTime.getEpochSecond()
+                + "))\n"
                 + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= "
                 + fromTime.getEpochSecond() + ")\n" + "  )\n" + ")";
         result = parser.fromString(q, false).toString();
@@ -213,18 +212,18 @@ public class XmlToSqlTest {
         q = "<OR><AND><AND><index value=\"haproxy\" operation=\"NOT_EQUALS\"/><sourcetype value=\"example:haproxy:haproxy\" operation=\"EQUALS\"/></AND><host value=\"loadbalancer.example.com\" operation=\"EQUALS\"/></AND><AND><AND><AND><AND><index value=\"*\" operation=\"EQUALS\"/><host value=\"firewall.example.com\" operation=\"EQUALS\"/></AND><earliest value=\"1611657303\" operation=\"GE\"/></AND><latest value=\"1619437701\" operation=\"LE\"/></AND><indexstring value=\"Denied\" /></AND></OR>";
         // Add time ranges
         Instant fromTime = Instant.ofEpochSecond(1611655200);
-        Date fromDate = new Date(fromTime.toEpochMilli());
         Instant toTime = Instant.ofEpochSecond(1619437701);
-        Date toDate = new Date(toTime.toEpochMilli());
         e = "(\n" + "  (\n" + "    not (\"getArchivedObjects_filter_table\".\"directory\" like 'haproxy')\n"
                 + "    and \"getArchivedObjects_filter_table\".\"stream\" like 'example:haproxy:haproxy'\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'loadbalancer.example.com'\n" + "  )\n"
                 + "  or (\n" + "    true\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'firewall.example.com'\n"
-                + "    and \"journaldb\".\"logfile\".\"logdate\" >= date '" + fromDate + "'\n"
+                + "    and \"journaldb\".\"logfile\".\"logdate\" >= DATE(FROM_UNIXTIME(" + fromTime.getEpochSecond()
+                + "))\n"
                 + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= "
-                + fromTime.getEpochSecond() + ")\n" + "    and \"journaldb\".\"logfile\".\"logdate\" <= date '" + toDate
-                + "'\n"
+                + fromTime.getEpochSecond() + ")\n"
+                + "    and \"journaldb\".\"logfile\".\"logdate\" <= DATE(FROM_UNIXTIME(" + toTime.getEpochSecond()
+                + "))\n"
                 + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= "
                 + toTime.getEpochSecond() + ")\n" + "  )\n" + ")";
         result = parser.fromString(q, false).toString();
@@ -242,17 +241,17 @@ public class XmlToSqlTest {
         q = "<AND><AND><AND><host value=\"sc-99-99-14-25\" operation=\"EQUALS\"/><index value=\"cpu\" operation=\"EQUALS\"/></AND><sourcetype value=\"log:cpu:0\" operation=\"EQUALS\"/></AND><AND><earliest value=\"0\" operation=\"GE\"/><latest value=\"1893491420\" operation=\"LE\"/></AND></AND>";
         // Add time ranges
         Instant fromTime = Instant.ofEpochSecond(0);
-        Date fromDate = new Date(fromTime.toEpochMilli());
         Instant toTime = Instant.ofEpochSecond(1893491420);
-        Date toDate = new Date(toTime.toEpochMilli());
 
         e = "(\n" + "  \"getArchivedObjects_filter_table\".\"host\" like 'sc-99-99-14-25'\n"
                 + "  and \"getArchivedObjects_filter_table\".\"directory\" like 'cpu'\n"
                 + "  and \"getArchivedObjects_filter_table\".\"stream\" like 'log:cpu:0'\n"
-                + "  and \"journaldb\".\"logfile\".\"logdate\" >= date '" + fromDate + "'\n"
+                + "  and \"journaldb\".\"logfile\".\"logdate\" >= DATE(FROM_UNIXTIME(" + fromTime.getEpochSecond()
+                + "))\n"
                 + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= "
-                + fromTime.getEpochSecond() + ")\n" + "  and \"journaldb\".\"logfile\".\"logdate\" <= date '" + toDate
-                + "'\n"
+                + fromTime.getEpochSecond() + ")\n"
+                + "  and \"journaldb\".\"logfile\".\"logdate\" <= DATE(FROM_UNIXTIME(" + toTime.getEpochSecond()
+                + "))\n"
                 + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= "
                 + toTime.getEpochSecond() + ")\n" + ")";
         result = parser.fromString(q, false).toString();

--- a/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
@@ -626,9 +626,6 @@ class StreamDBClientTest {
         Assertions.assertTrue(nextHourAndSizeFromSliceTable.isStub);
     }
 
-    @Disabled(
-        "EarliectCondition will not work properly if MariaDB is in a lower timezone than the JVM, see issue #355 for details."
-    )
     @Test
     public void earliestConditionQueryTest() {
         // Add test data to logfile table in journaldb.
@@ -675,9 +672,6 @@ class StreamDBClientTest {
         });
     }
 
-    @Disabled(
-        "LatestCondition will not work properly if MariaDB is in a higher timezone than the JVM, see issue #355 for details."
-    )
     @Test
     public void latestConditionQueryTest() {
         // Add test data to logfile table in journaldb.

--- a/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/StreamDBClientTest.java
@@ -724,6 +724,33 @@ class StreamDBClientTest {
         });
     }
 
+    /**
+     * Verifies that logdate filtering uses the database session timezone instead of the JVM timezone. This test relies
+     * on the test JVM timezone being different enough from the MariaDB session timezone (America/New_York) that
+     * 2023-10-04 22:00 America/New_York falls on a different calendar date. Workflow runners currently runs with UTC,
+     * which reproduces the original issue.
+     */
+    @Test
+    public void logfileDateFilteringUsesDatabaseSessionTimezoneTest() {
+        final DSLContext ctx = DSL.using(connection, SQLDialect.MYSQL);
+        // 2023-10-04 22:00 America/New_York = 2023-10-05 02:00 UTC
+        final ZonedDateTime logTime = ZonedDateTime.of(2023, 10, 4, 22, 0, 0, 0, zoneId);
+        final long epoch = logTime.toEpochSecond();
+        ctx.insertInto(JOURNALDB.LOGFILE).set(logfileRecordForEpoch(epoch, false)).execute();
+        final Map<String, String> opts = new HashMap<>(this.opts);
+        opts.put("DBurl", mariadb.getJdbcUrl());
+        final String query = "<AND>" + "<index value=\"example\" operation=\"EQUALS\"/>" + "<earliest value=\"" + epoch
+                + "\" operation=\"GE\"/>" + "</AND>";
+        opts.put("queryXML", query);
+        final Config config = new Config(opts);
+        Assertions.assertDoesNotThrow(() -> {
+            try (StreamDBClient sdc = new StreamDBClient(config)) {
+                int rows = sdc.pullToSliceTable(Date.valueOf(logTime.toLocalDate()));
+                Assertions.assertEquals(1, rows, "Should find the row");
+            }
+        });
+    }
+
     @Test
     public void equalsHashCodeContractTest() {
         EqualsVerifier

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
@@ -68,7 +68,7 @@ public class EarliestConditionTest {
     }
 
     @Test
-    public void conditionRoundsToHourlyBoundaryTest() {
+    public void conditionTruncatesToHourlyBoundaryTest() {
         String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" >= DATE(FROM_UNIXTIME(3600))\n"
                 + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 3600)\n"
                 + ")";

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/EarliestConditionTest.java
@@ -60,11 +60,20 @@ public class EarliestConditionTest {
 
     @Test
     public void conditionTest() {
-        String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" >= date '1970-01-01'\n"
+        String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" >= DATE(FROM_UNIXTIME(0))\n"
                 + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 0)\n"
                 + ")";
-        Condition elementCondition = new EarliestCondition("1000").condition();
-        Assertions.assertEquals(e, elementCondition.toString());
+        Condition condition = new EarliestCondition("1000").condition();
+        Assertions.assertEquals(e, condition.toString());
+    }
+
+    @Test
+    public void conditionRoundsToHourlyBoundaryTest() {
+        String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" >= DATE(FROM_UNIXTIME(3600))\n"
+                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 3600)\n"
+                + ")";
+        Condition condition = new EarliestCondition("3700").condition();
+        Assertions.assertEquals(e, condition.toString());
     }
 
     @Test

--- a/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
+++ b/src/test/java/com/teragrep/pth_06/planner/walker/conditions/LatestConditionTest.java
@@ -60,7 +60,7 @@ public class LatestConditionTest {
 
     @Test
     public void conditionTest() {
-        String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" <= date '1970-01-01'\n"
+        String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" <= DATE(FROM_UNIXTIME(1000))\n"
                 + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1000)\n"
                 + ")";
         Condition elementCondition = new LatestCondition("1000").condition();
@@ -69,7 +69,7 @@ public class LatestConditionTest {
 
     @Test
     public void conditionUpdatedTest() {
-        String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" <= date '2000-01-01'\n"
+        String e = "(\n" + "  \"journaldb\".\"logfile\".\"logdate\" <= DATE(FROM_UNIXTIME(946720800))\n"
                 + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 946720800)\n"
                 + ")";
         Condition elementCondition = new LatestCondition("946720800").condition();

--- a/src/test/java/com/teragrep/pth_06/walker/ConditionWalkerTest.java
+++ b/src/test/java/com/teragrep/pth_06/walker/ConditionWalkerTest.java
@@ -249,13 +249,16 @@ public class ConditionWalkerTest {
         DSLContext ctx = DSL.using(conn);
         ConditionWalker walker = new ConditionWalker(ctx, true, new FilterlessSearchImpl(ctx, ipRegex));
         String q = "<AND><index operation=\"EQUALS\" value=\"haproxy\"/><AND><earliest operation=\"GE\" value=\"1643207821\"/><latest operation=\"LE\" value=\"1729435021\"/></AND></AND>";
-        String e = "(\n" + "  \"bloomdb\".\"pattern_test_ip\".\"filter\" is null\n"
-                + "  and \"getArchivedObjects_filter_table\".\"directory\" like 'haproxy'\n"
-                + "  and \"journaldb\".\"logfile\".\"logdate\" >= date '2022-01-26'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1643205600)\n"
-                + "  and \"journaldb\".\"logfile\".\"logdate\" <= date '2024-10-20'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1729435021)\n"
-                + ")";
+        // spotless:off
+        String e = "(\n" +
+                "  \"bloomdb\".\"pattern_test_ip\".\"filter\" is null\n" +
+                "  and \"getArchivedObjects_filter_table\".\"directory\" like 'haproxy'\n" +
+                "  and \"journaldb\".\"logfile\".\"logdate\" >= DATE(FROM_UNIXTIME(1643205600))\n" +
+                "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1643205600)\n" +
+                "  and \"journaldb\".\"logfile\".\"logdate\" <= DATE(FROM_UNIXTIME(1729435021))\n" +
+                "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1729435021)\n" +
+                ")";
+        // spotless:on
         Condition cond = Assertions.assertDoesNotThrow(() -> walker.fromString(q, false));
         Assertions.assertEquals(e, cond.toString());
         Assertions.assertEquals(1, walker.conditionRequiredTables().size());
@@ -296,24 +299,49 @@ public class ConditionWalkerTest {
     void testFullXMLTwoMatchingTables() {
         ConditionWalker walker = new ConditionWalker(DSL.using(conn), true);
         String q = "<AND><index operation=\"EQUALS\" value=\"search_bench\"/><AND><AND><AND><earliest operation=\"GE\" value=\"1643207821\"/><latest operation=\"LE\" value=\"1729435021\"/></AND><indexstatement operation=\"EQUALS\" value=\"192.168.1.1\"/></AND><indexstatement operation=\"EQUALS\" value=\"192.000.1.1\"/></AND></AND>";
-        String e = "(\n" + "  \"getArchivedObjects_filter_table\".\"directory\" like 'search_bench'\n"
-                + "  and \"journaldb\".\"logfile\".\"logdate\" >= date '2022-01-26'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1643205600)\n"
-                + "  and \"journaldb\".\"logfile\".\"logdate\" <= date '2024-10-20'\n"
-                + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1729435021)\n"
-                + "  and (\n" + "    (\n" + "      bloommatch(\n" + "        (\n"
-                + "          select \"term_0_pattern_test_ip\".\"filter\"\n"
-                + "          from \"term_0_pattern_test_ip\"\n" + "          where (\n" + "            term_id = 0\n"
-                + "            and type_id = \"bloomdb\".\"pattern_test_ip\".\"filter_type_id\"\n" + "          )\n"
-                + "        ),\n" + "        \"bloomdb\".\"pattern_test_ip\".\"filter\"\n" + "      ) = true\n"
-                + "      and \"bloomdb\".\"pattern_test_ip\".\"filter\" is not null\n" + "    )\n"
-                + "    or \"bloomdb\".\"pattern_test_ip\".\"filter\" is null\n" + "  )\n" + "  and (\n" + "    (\n"
-                + "      bloommatch(\n" + "        (\n" + "          select \"term_1_pattern_test_ip\".\"filter\"\n"
-                + "          from \"term_1_pattern_test_ip\"\n" + "          where (\n" + "            term_id = 1\n"
-                + "            and type_id = \"bloomdb\".\"pattern_test_ip\".\"filter_type_id\"\n" + "          )\n"
-                + "        ),\n" + "        \"bloomdb\".\"pattern_test_ip\".\"filter\"\n" + "      ) = true\n"
-                + "      and \"bloomdb\".\"pattern_test_ip\".\"filter\" is not null\n" + "    )\n"
-                + "    or \"bloomdb\".\"pattern_test_ip\".\"filter\" is null\n" + "  )\n" + ")";
+        // spotless:off
+        String e = "(\n" +
+                "  \"getArchivedObjects_filter_table\".\"directory\" like 'search_bench'\n" +
+                "  and \"journaldb\".\"logfile\".\"logdate\" >= DATE(FROM_UNIXTIME(1643205600))\n" +
+                "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1643205600)\n" +
+                "  and \"journaldb\".\"logfile\".\"logdate\" <= DATE(FROM_UNIXTIME(1729435021))\n" +
+                "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1729435021)\n" +
+                "  and (\n" +
+                "    (\n" +
+                "      bloommatch(\n" +
+                "        (\n" +
+                "          select \"term_0_pattern_test_ip\".\"filter\"\n" +
+                "          from \"term_0_pattern_test_ip\"\n" +
+                "          where (\n" +
+                "            term_id = 0\n" +
+                "            and type_id = \"bloomdb\".\"pattern_test_ip\".\"filter_type_id\"\n" +
+                "          )\n" +
+                "        ),\n" +
+                "        \"bloomdb\".\"pattern_test_ip\".\"filter\"\n" +
+                "      ) = true\n" +
+                "      and \"bloomdb\".\"pattern_test_ip\".\"filter\" is not null\n" +
+                "    )\n" +
+                "    or \"bloomdb\".\"pattern_test_ip\".\"filter\" is null\n" +
+                "  )\n" +
+                "  and (\n" +
+                "    (\n" +
+                "      bloommatch(\n" +
+                "        (\n" +
+                "          select \"term_1_pattern_test_ip\".\"filter\"\n" +
+                "          from \"term_1_pattern_test_ip\"\n" +
+                "          where (\n" +
+                "            term_id = 1\n" +
+                "            and type_id = \"bloomdb\".\"pattern_test_ip\".\"filter_type_id\"\n" +
+                "          )\n" +
+                "        ),\n" +
+                "        \"bloomdb\".\"pattern_test_ip\".\"filter\"\n" +
+                "      ) = true\n" +
+                "      and \"bloomdb\".\"pattern_test_ip\".\"filter\" is not null\n" +
+                "    )\n" +
+                "    or \"bloomdb\".\"pattern_test_ip\".\"filter\" is null\n" +
+                "  )\n" +
+                ")";
+        // spotless:on
         Condition cond = Assertions.assertDoesNotThrow(() -> walker.fromString(q, false));
         Assertions.assertEquals(e, cond.toString());
     }

--- a/src/test/java/com/teragrep/pth_06/walker/XmlWalkerTest.java
+++ b/src/test/java/com/teragrep/pth_06/walker/XmlWalkerTest.java
@@ -187,7 +187,7 @@ public class XmlWalkerTest {
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'loadbalancer.example.com'\n" + "  )\n"
                 + "  or (\n" + "    true\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'firewall.example.com'\n"
-                + "    and \"journaldb\".\"logfile\".\"logdate\" >= date '2021-01-26'\n"
+                + "    and \"journaldb\".\"logfile\".\"logdate\" >= DATE(FROM_UNIXTIME(1611655200))\n"
                 + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1611655200)\n"
                 + "  )\n" + ")";
         result = conditionWalker.fromString(q, false).toString();
@@ -203,9 +203,9 @@ public class XmlWalkerTest {
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'loadbalancer.example.com'\n" + "  )\n"
                 + "  or (\n" + "    true\n"
                 + "    and \"getArchivedObjects_filter_table\".\"host\" like 'firewall.example.com'\n"
-                + "    and \"journaldb\".\"logfile\".\"logdate\" >= date '2021-01-26'\n"
+                + "    and \"journaldb\".\"logfile\".\"logdate\" >= DATE(FROM_UNIXTIME(1611655200))\n"
                 + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 1611655200)\n"
-                + "    and \"journaldb\".\"logfile\".\"logdate\" <= date '2021-04-26'\n"
+                + "    and \"journaldb\".\"logfile\".\"logdate\" <= DATE(FROM_UNIXTIME(1619437701))\n"
                 + "    and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1619437701)\n"
                 + "  )\n" + ")";
         Condition cond = conditionWalker.fromString(q, false);
@@ -225,9 +225,9 @@ public class XmlWalkerTest {
         e = "(\n" + "  \"getArchivedObjects_filter_table\".\"host\" like 'sc-99-99-14-25'\n"
                 + "  and \"getArchivedObjects_filter_table\".\"directory\" like 'cpu'\n"
                 + "  and \"getArchivedObjects_filter_table\".\"stream\" like 'log:cpu:0'\n"
-                + "  and \"journaldb\".\"logfile\".\"logdate\" >= date '1970-01-01'\n"
+                + "  and \"journaldb\".\"logfile\".\"logdate\" >= DATE(FROM_UNIXTIME(0))\n"
                 + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) >= 0)\n"
-                + "  and \"journaldb\".\"logfile\".\"logdate\" <= date '2030-01-01'\n"
+                + "  and \"journaldb\".\"logfile\".\"logdate\" <= DATE(FROM_UNIXTIME(1893491420))\n"
                 + "  and (UNIX_TIMESTAMP(STR_TO_DATE(SUBSTRING(REGEXP_SUBSTR(path,'[0-9]+(\\.rfc5424)?(\\.log)?\\.gz(\\.[0-9]*)?$'), 1, 10), '%Y%m%d%H')) <= 1893491420)\n"
                 + ")";
         Condition cond = conditionWalker.fromString(q, false);


### PR DESCRIPTION
## Description
Resolves #355 

Use MariaDB's `FROM_UNIXTIME()` function to calculate dates in `EarliestCondition` and `LatestCondition`.

Previously, epoch values were converted to `java.sql.Date` in the JVM timezone before being used in the SQL condition. This caused the generated logdate condition to depend on the JVM timezone, while the logtime condition depended on the MariaDB session timezone.

By moving the epoch-to-date conversion to MariaDB, both conditions now use the MariaDB session timezone consistently.

This affects existing tests containing earliest or latest conditions because the generated SQL now uses `DATE(FROM_UNIXTIME(...))` instead of a date literal.

Note: MariaDB documentation recommends using a named timezone (for example `UTC` or `Europe/Helsinki`) instead of offsets to avoid timezone-related performance issues.

[FROM_UNIXTIME() documentation](https://mariadb.com/docs/server/reference/sql-functions/date-time-functions/from_unixtime)

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods. 

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [x] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.  
